### PR TITLE
Run twine check and download release artifact to dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
           python-version: '3.10'
       - name: Build wheel
         run: |
-          pip install build
+          pip install build twine
           python -m build
+          python -m twine check dist/*
       - name: Upload Python package dist artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: python-package-dist
-          path: |
-            dist
+          path: dist
 
   pypi-publish:
     name: Upload release to PyPI
@@ -40,5 +39,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: python-package-dist
+        path: dist
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds a twine check to verify the dist packages to upload look okay, and download the release artifact to the dist folder for the publish-pypi job.