### PR TITLE
Enable Windows CI builds

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:


### PR DESCRIPTION
Re-enable Windows CI builds now that a portable path normalization function has been added that should behave the same way on Windows.

Resolves #7