### PR TITLE
Fix no StringTable Attribute

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -277,7 +277,7 @@ def sbom(
                                     )
                                 )
                             except Exception as e:
-                                raise Exception(f"Unable to process: {filepath}") from e
+                                raise RuntimeError(f"Unable to process: {filepath}") from e
 
                             if file_is_symlink and install_prefix:
                                 # Remove the entry from the list as it'll be processed later anyways

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -263,18 +263,21 @@ def sbom(
                             filepath = true_filepath
 
                         if ftype := pm.hook.identify_file_type(filepath=filepath):
-                            entries.append(
-                                get_software_entry(
-                                    pm,
-                                    new_sbom,
-                                    filepath,
-                                    filetype=ftype,
-                                    root_path=epath,
-                                    container_uuid=parent_uuid,
-                                    install_path=install_prefix,
-                                    user_institution_name=recorded_institution,
+                            try:
+                                entries.append(
+                                    get_software_entry(
+                                        pm,
+                                        new_sbom,
+                                        filepath,
+                                        filetype=ftype,
+                                        root_path=epath,
+                                        container_uuid=parent_uuid,
+                                        install_path=install_prefix,
+                                        user_institution_name=recorded_institution,
+                                    )
                                 )
-                            )
+                            except Exception as e:
+                                raise Exception(f"Unable to process: {filepath}") from e
 
                             if file_is_symlink and install_prefix:
                                 # Remove the entry from the list as it'll be processed later anyways

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -139,7 +139,7 @@ def extract_pe_info(filename):
         if len(pe_fi) > 0:
             file_details["FileInfo"] = {}
             for fi_entry in pe_fi[0]:
-                if fi_entry.name == "StringFileInfo":
+                if fi_entry.name == "StringFileInfo" and hasattr(fi_entry, "StringTable"):
                     for st in fi_entry.StringTable:
                         for st_entry in st.entries.items():
                             file_details["FileInfo"][st_entry[0].decode()] = st_entry[1].decode()


### PR DESCRIPTION
This PR addresses an issue where Surfactant will crash when a binary causes the "StringFileInfo" structure to not have a "StringTable" attribute (#30).

Additionally, this PR adds additional debugging information by chaining the filename information to exceptions caused by processing a file.

Closes #30 