### PR TITLE
Add wheel package to build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
It seems like some systems (likely with older versions of Python or pip) may require `wheel` to be listed as a build-system requirement for installing Surfactant from source.

@RazerNinjas -- check if this works on the system you were getting the failures on.

Resolves #25.