### PR TITLE
Use extractPaths as installPrefix when not given

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ The resulting SBOM would be structured like this:
         {
           "UUID": "abc1",
           "fileName": ["helics_binary"],
-          "installPath": "/home/samples/helics/bin",
+          "installPath": ["/home/samples/helics/bin/helics_binary"],
           "containerPath": null
         },
         {
           "UUID": "abc2",
           "fileName": ["lib1.so"],
-          "installPath": "/home/samples/helics/bin",
+          "installPath": ["/home/samples/helics/bin/lib1.so"],
           "containerPath": null
         }
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A configuration file contains the information about the sample to gather informa
 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\
-**installPrefix**: (optional) where the files in **extractPaths** would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc (Note that even on Windows, Unix style `/` directory separators should be used in the path)
+**installPrefix**: (optional) where the files in **extractPaths** would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc (Note that even on Windows, Unix style `/` directory separators should be used in the path). If not given then the **extractPaths** will be used as the install paths
 
 #### Example configuration file
 Lets say you have a .tar.gz file that you want to run surfactant on. For this example, we will be using the HELICS release .tar.gz example. In this scenario, the absolute path for this file is `/home/samples/helics.tar.gz`. Upon extracting this file, we get a helics folder with 4 sub-folders: bin, include, lib64, and share.
@@ -83,18 +83,24 @@ The resulting SBOM would be structured like this:
         {
           "UUID": "abc1",
           "fileName": ["helics_binary"],
-          "installPath": null,
+          "installPath": "/home/samples/helics/bin",
           "containerPath": null
         },
         {
           "UUID": "abc2",
           "fileName": ["lib1.so"],
-          "installPath": null,
+          "installPath": "/home/samples/helics/bin",
           "containerPath": null
         }
 
     ],
-    "relationships": []
+    "relationships": [
+        {
+          "xUUID": "abc1",
+          "yUUID": "abc2",
+          "relationship": "Uses"
+        }
+    ]
 }
 ```
 ##### Example 2: Detailed Configuration File
@@ -264,6 +270,7 @@ $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 **INPUT_SBOM**: (optional) a base sbom, should be used with care as relationships could be messed up when files are installed on different systems\
 **--skip_gather**: (optional) skips the gathering of information on files and adding software entires\
 **--skip_relationships**: (optional) skips the adding of relationships based on metadata\
+**--skip_install_path**: (optional) skips including an install path for the files discovered. This may cause "Uses" relationships to also not be generated\
 **--recorded_institution**: (optional) the name of the institution collecting the SBOM data (default: LLNL)\
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
 **--help**: (optional) show the help message and exit

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The resulting SBOM would be structured like this:
         {
           "UUID": "abc2",
           "fileName": ["lib1.so"],
-          "installPath": ["/home/samples/helics/bin/lib1.so"],
+          "installPath": ["/home/samples/helics/lib64/lib1.so"],
           "containerPath": null
         }
 

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -125,7 +125,7 @@ def print_output_formats(ctx, _, value):
     is_flag=True,
     default=False,
     required=False,
-    help="Skip including install path information if not given by configuration"
+    help="Skip including install path information if not given by configuration",
 )
 @click.option(
     "--recorded_institution", is_flag=False, default="LLNL", help="Name of user's institution"

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -125,7 +125,7 @@ def print_output_formats(ctx, _, value):
     is_flag=True,
     default=False,
     required=False,
-    help="Skip including install path information"
+    help="Skip including install path information if not given by configuration"
 )
 @click.option(
     "--recorded_institution", is_flag=False, default="LLNL", help="Name of user's institution"
@@ -279,6 +279,14 @@ def sbom(
                             # We need get_software_entry to look at the true filepath
                             filepath = true_filepath
 
+                        if install_prefix is not None:
+                            install_path = install_prefix
+                        elif not skip_install_path:
+                            # epath is guaranteed to not have an ending slash due to formatting above
+                            install_path = epath + "/"
+                        else:
+                            install_path = None
+
                         if ftype := pm.hook.identify_file_type(filepath=filepath):
                             try:
                                 entries.append(
@@ -289,7 +297,7 @@ def sbom(
                                         filetype=ftype,
                                         root_path=epath,
                                         container_uuid=parent_uuid,
-                                        install_path=install_prefix,
+                                        install_path=install_path,
                                         user_institution_name=recorded_institution,
                                     )
                                 )

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -121,6 +121,13 @@ def print_output_formats(ctx, _, value):
     help="Skip adding relationships based on Linux/Windows/etc metadata",
 )
 @click.option(
+    "--skip_install_path",
+    is_flag=True,
+    default=False,
+    required=False,
+    help="Skip including install path information"
+)
+@click.option(
     "--recorded_institution", is_flag=False, default="LLNL", help="Name of user's institution"
 )
 @click.option(
@@ -143,6 +150,7 @@ def sbom(
     input_sbom,
     skip_gather,
     skip_relationships,
+    skip_install_path,
     recorded_institution,
     output_format,
 ):

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -29,10 +29,23 @@ def test_generate_no_install_prefix(tmp_path):
     actual_software_names = {software["fileName"][0] for software in generated_sbom["software"]}
     assert expected_software_names == actual_software_names
 
+    expected_install_paths = {
+        "hello_world.exe": extract_path + "/hello_world.exe",
+        "testlib.dll": extract_path + "/testlib.dll",
+    }
     for software in generated_sbom["software"]:
-        assert software["installPath"] == []
+        assert (
+            software["installPath"][0]
+            == expected_install_paths[software["fileName"][0]]
+        )
 
-    assert len(generated_sbom["relationships"]) == 0
+    uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
+    assert len(generated_sbom["relationships"]) == 1
+    assert generated_sbom["relationships"][0] == {
+        "xUUID": uuids["hello_world.exe"],
+        "yUUID": uuids["testlib.dll"],
+        "relationship": "Uses",
+    }
 
 
 def test_generate_with_install_prefix(tmp_path):
@@ -63,7 +76,10 @@ def test_generate_with_install_prefix(tmp_path):
         "testlib.dll": "test_prefix/testlib.dll",
     }
     for software in generated_sbom["software"]:
-        assert software["installPath"][0] == expected_install_paths[software["fileName"][0]]
+        assert (
+            software["installPath"][0]
+            == expected_install_paths[software["fileName"][0]]
+        )
 
     uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
     assert len(generated_sbom["relationships"]) == 1
@@ -72,3 +88,32 @@ def test_generate_with_install_prefix(tmp_path):
         "yUUID": uuids["testlib.dll"],
         "relationship": "Uses",
     }
+
+
+def test_generate_with_skip_install_path(tmp_path):
+    extract_path = Path(testing_data, "Windows_dll_test_no1").as_posix()
+    config_data = f'[{{"extractPaths": ["{extract_path}"]}}]'
+    config_path = str(Path(tmp_path, "config.json"))
+    output_path = str(Path(tmp_path, "out.json"))
+
+    with open(config_path, "w") as f:
+        f.write(config_data)
+
+    # the click.testing module would be better here but it doesn't allow for files to be generated
+    # pylint: disable=no-value-for-parameter
+    sbom(["--skip_install_path", config_path, output_path], standalone_mode=False)
+    # pylint: enable
+
+    with open(output_path) as f:
+        generated_sbom = json.load(f)
+
+    assert len(generated_sbom["software"]) == 2
+
+    expected_software_names = {"hello_world.exe", "testlib.dll"}
+    actual_software_names = {software["fileName"][0] for software in generated_sbom["software"]}
+    assert expected_software_names == actual_software_names
+
+    for software in generated_sbom["software"]:
+        assert software["installPath"] == []
+
+    assert len(generated_sbom["relationships"]) == 0

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -34,10 +34,7 @@ def test_generate_no_install_prefix(tmp_path):
         "testlib.dll": extract_path + "/testlib.dll",
     }
     for software in generated_sbom["software"]:
-        assert (
-            software["installPath"][0]
-            == expected_install_paths[software["fileName"][0]]
-        )
+        assert software["installPath"][0] == expected_install_paths[software["fileName"][0]]
 
     uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
     assert len(generated_sbom["relationships"]) == 1
@@ -76,10 +73,7 @@ def test_generate_with_install_prefix(tmp_path):
         "testlib.dll": "test_prefix/testlib.dll",
     }
     for software in generated_sbom["software"]:
-        assert (
-            software["installPath"][0]
-            == expected_install_paths[software["fileName"][0]]
-        )
+        assert software["installPath"][0] == expected_install_paths[software["fileName"][0]]
 
     uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
     assert len(generated_sbom["relationships"]) == 1


### PR DESCRIPTION
This PR makes the following changes:

- If a configuration file does not provide an `installPrefix` then the `extractPaths` will be used to generate the `installPath` of each enumerated binary. This makes it so that "Uses" relationships will be generated by default when no `installPath` is given.
- A new flag, **--skip_install_path** has been added. This flag will turn off the new default behavior so that if an `installPrefix` is not given then no `installPath` will be generated.
- The README has been updated to document the new flag and the new behavior.
- Tests for the generate command have been added that demonstrate the new behavior.

A couple notes:
- I wasn't sure how tests were expected to be added in this situation, so I just took a shot at it. I'm open to refactoring them or removing them as needed.
- The tests invoke the generate command programmatically, but they do not use the `click.testing` module. This is because click's testing module shuts off writing to the filesystem so the sbom could not be generated. A future addition to allow for output to be redirected to stdout could help with this.
- I tried testing with situations that used symlinks and what I could do seemed to work for me. However, I admit that I am not confident that I tested this thoroughly.

Closes #32 

