### PR TITLE
Fix Windows Pathing

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -240,7 +240,7 @@ def sbom(
                     for f in files:
                         # os.path.join will insert an OS specific separator between cdir and f
                         # need to make sure that separator is a / and not a \ on windows
-                        filepath = os.path.join(cdir, f).replace("\\", "/")
+                        filepath = pathlib.Path(cdir, f).as_posix()
                         file_is_symlink = False
                         if os.path.islink(filepath):
                             true_filepath = resolve_link(filepath, cdir, epath)

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -238,7 +238,9 @@ def sbom(
 
                     entries: List[Software] = []
                     for f in files:
-                        filepath = os.path.join(cdir, f)
+                        # os.path.join will insert an OS specific separator between cdir and f
+                        # need to make sure that separator is a / and not a \ on windows
+                        filepath = os.path.join(cdir, f).replace("\\", "/")
                         file_is_symlink = False
                         if os.path.islink(filepath):
                             true_filepath = resolve_link(filepath, cdir, epath)

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -30,9 +30,7 @@ def test_generate_no_install_prefix(tmp_path):
     assert expected_software_names == actual_software_names
 
     for software in generated_sbom["software"]:
-        assert (
-            software["installPath"] == []
-        )
+        assert software["installPath"] == []
 
     assert len(generated_sbom["relationships"]) == 0
 

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -63,10 +63,7 @@ def test_generate_with_install_prefix(tmp_path):
         "testlib.dll": "test_prefix/testlib.dll",
     }
     for software in generated_sbom["software"]:
-        assert (
-            software["installPath"][0]
-            == expected_install_paths[software["fileName"][0]]
-        )
+        assert software["installPath"][0] == expected_install_paths[software["fileName"][0]]
 
     uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
     assert len(generated_sbom["relationships"]) == 1

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -64,7 +64,7 @@ def test_generate_with_install_prefix(tmp_path):
     }
     for software in generated_sbom["software"]:
         assert (
-            software["installPath"][0].replace("\\", "/")
+            software["installPath"][0]
             == expected_install_paths[software["fileName"][0]]
         )
 

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+from surfactant.cmd.generate import sbom
+
+testing_data = Path(Path(__file__).parent.parent, "data")
+
+
+def test_generate_no_install_prefix(tmp_path):
+    extract_path = str(Path(testing_data, "Windows_dll_test_no1")).replace("\\", "/")
+    config_data = f'[{{"extractPaths": ["{extract_path}"]}}]'
+    config_path = str(Path(tmp_path, "config.json"))
+    output_path = str(Path(tmp_path, "out.json"))
+
+    with open(config_path, "w") as f:
+        f.write(config_data)
+
+    # the click.testing module would be better here but it doesn't allow for files to be generated
+    # pylint: disable=no-value-for-parameter
+    sbom([config_path, output_path], standalone_mode=False)
+    # pylint: enable
+
+    with open(output_path) as f:
+        generated_sbom = json.load(f)
+
+    assert len(generated_sbom["software"]) == 2
+
+    expected_software_names = {"hello_world.exe", "testlib.dll"}
+    actual_software_names = {software["fileName"][0] for software in generated_sbom["software"]}
+    assert expected_software_names == actual_software_names
+
+    for software in generated_sbom["software"]:
+        assert (
+            software["installPath"] == []
+        )
+
+    assert len(generated_sbom["relationships"]) == 0
+
+
+def test_generate_with_install_prefix(tmp_path):
+    extract_path = str(Path(testing_data, "Windows_dll_test_no1")).replace("\\", "/")
+    config_data = f'[{{"extractPaths": ["{extract_path}"], "installPrefix": "test_prefix/"}}]'
+    config_path = str(Path(tmp_path, "config.json"))
+    output_path = str(Path(tmp_path, "out.json"))
+
+    with open(config_path, "w") as f:
+        f.write(config_data)
+
+    # the click.testing module would be better here but it doesn't allow for files to be generated
+    # pylint: disable=no-value-for-parameter
+    sbom([config_path, output_path], standalone_mode=False)
+    # pylint: enable
+
+    with open(output_path) as f:
+        generated_sbom = json.load(f)
+
+    assert len(generated_sbom["software"]) == 2
+
+    expected_software_names = {"hello_world.exe", "testlib.dll"}
+    actual_software_names = {software["fileName"][0] for software in generated_sbom["software"]}
+    assert expected_software_names == actual_software_names
+
+    expected_install_paths = {
+        "hello_world.exe": "test_prefix/hello_world.exe",
+        "testlib.dll": "test_prefix/testlib.dll",
+    }
+    for software in generated_sbom["software"]:
+        assert (
+            software["installPath"][0].replace("\\", "/")
+            == expected_install_paths[software["fileName"][0]]
+        )
+
+    uuids = {software["fileName"][0]: software["UUID"] for software in generated_sbom["software"]}
+    assert len(generated_sbom["relationships"]) == 1
+    assert generated_sbom["relationships"][0] == {
+        "xUUID": uuids["hello_world.exe"],
+        "yUUID": uuids["testlib.dll"],
+        "relationship": "Uses",
+    }

--- a/tests/cmd/test_generate.py
+++ b/tests/cmd/test_generate.py
@@ -7,7 +7,7 @@ testing_data = Path(Path(__file__).parent.parent, "data")
 
 
 def test_generate_no_install_prefix(tmp_path):
-    extract_path = str(Path(testing_data, "Windows_dll_test_no1")).replace("\\", "/")
+    extract_path = Path(testing_data, "Windows_dll_test_no1").as_posix()
     config_data = f'[{{"extractPaths": ["{extract_path}"]}}]'
     config_path = str(Path(tmp_path, "config.json"))
     output_path = str(Path(tmp_path, "out.json"))
@@ -36,7 +36,7 @@ def test_generate_no_install_prefix(tmp_path):
 
 
 def test_generate_with_install_prefix(tmp_path):
-    extract_path = str(Path(testing_data, "Windows_dll_test_no1")).replace("\\", "/")
+    extract_path = Path(testing_data, "Windows_dll_test_no1").as_posix()
     config_data = f'[{{"extractPaths": ["{extract_path}"], "installPrefix": "test_prefix/"}}]'
     config_path = str(Path(tmp_path, "config.json"))
     output_path = str(Path(tmp_path, "out.json"))


### PR DESCRIPTION
This PR addresses an issue where the `installPath` was not being updated with a configured `installPrefix` when ran on Windows. The issue stemmed from `os.path.join` inserting platform specific separators between path components. So, `os.path.join("C:/folder", "file")` would generate `C:/folder\file`. To fix that, this PR removes all backslashes from the generated path and replaces them with forward slashes.

Additionally, this PR introduces tests for the generate command. I wasn't sure if those would be welcome, so I'm prepared to remove them if needed.

Fixes #44 