### PR TITLE
Added hook for reading CyTRICS format input SBOMs

### DIFF
--- a/README-PLUGIN.md
+++ b/README-PLUGIN.md
@@ -9,17 +9,20 @@ TODO: Once plugins are configurable, insert documentation on how to specify plug
 In order to create a plugin, you will need to write your implementation for one or more of the functions in the [hookspec.py](surfactant/plugin/hookspecs.py) file. Which functions you implement will depend on the goals of your plugin.
 
 #### Brief overview of functions
-[identify_file_type](surfactant/plugin/hookspecs.py#L11)
+[identify_file_type](surfactant/plugin/hookspecs.py#L15)
 - Return a string representation of the type of file passed in
 
-[extract_file_info](surfactant/plugin/hookspecs.py#L22)
+[extract_file_info](surfactant/plugin/hookspecs.py#L29)
 - Determine how file info is supposed to be extracted
 
-[establish_relationships](surfactant/plugin/hookspecs.py#L37)
+[establish_relationships](surfactant/plugin/hookspecs.py#L47)
 - Determines how to establish relationships between the software/metadata that has been passed to it
 
-[write_sbom](surfactant/plugin/hookspecs.py#L57)
+[write_sbom](surfactant/plugin/hookspecs.py#L70)
 - Determine what format to write the SBOM to file
+
+[read_sbom](surfactant/plugin/hookspecs.py#L80)
+- If reading from input SBOMs, specifies what format the input SBOMs are
 
 ### Step 2. Write .toml File
 Once you have written your plugin, you will need to write a pyproject.toml file. Include any relevant project metadata/dependencies for your plugin, as well as an entry-point specification (example below) to make the plugin discoverable by surfactant. Once you write your .toml file, you can `pip install .` your plugin.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 **--skip_install_path**: (optional) skips including an install path for the files discovered. This may cause "Uses" relationships to also not be generated\
 **--recorded_institution**: (optional) the name of the institution collecting the SBOM data (default: LLNL)\
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
+**--input_format**: (optional) specifies the format of the input SBOM if one is being used (default: cytrics) (given as full module name of a surfactant plugin implementing the `read_sbom` hook)\
 **--help**: (optional) show the help message and exit
 
 ## Understanding the SBOM Output

--- a/surfactant/input_readers/__init__.py
+++ b/surfactant/input_readers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT

--- a/surfactant/input_readers/cytrics_reader.py
+++ b/surfactant/input_readers/cytrics_reader.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from typing import Optional
+
+import surfactant.plugin
+from surfactant.sbomtypes import SBOM
+
+
+@surfactant.plugin.hookimpl
+def read_sbom(infile) -> SBOM:
+    return SBOM.from_json(infile.read())
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> Optional[str]:
+    return "cytrics"

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -78,5 +78,16 @@ def write_sbom(sbom: SBOM, outfile) -> None:
 
 
 @hookspec
+def read_sbom(infile) -> SBOM:
+    """Reads the contents of the input SBOM from the given input SBOM file.
+
+    Returns a SBOM object containing the input SBOM, which can be added to.
+
+    Args:
+        infile: The input file handle to read the SBOM from.
+    """
+
+
+@hookspec
 def short_name() -> Optional[str]:
     """A short name to register the hook as"""


### PR DESCRIPTION
Implemented hook for reading input SBOMs that are in the (default) CyTRICS format.

TODO: Add additional hooks for input SBOMs in SPDX and CycloneDX formats. 