### PR TITLE
create-config feature added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ __pycache__/
 
 # C extensions
 *.so
-cytrics_venv
 
 # Distribution / packaging
 .Python
@@ -136,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+cytrics_venv
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 
 # C extensions
 *.so
+cytrics_venv
 
 # Distribution / packaging
 .Python

--- a/README.md
+++ b/README.md
@@ -12,259 +12,287 @@ A modular framework to gather file information for SBOM generation and dependenc
 [Documentation](https://surfactant.readthedocs.io/en/latest/)
 
 ## Description
-Surfactant can be used to gather information from a set of files to generate an SBOM, along with manipulating SBOMs and analyzing the information in them.  It pulls information from recognized file types (such as PE, ELF, or MSI files) contained within a directory structure corresponding to an extracted software package.  By default, the information is "surface-level" metadata contained in the files that does not require running the files
+
+Surfactant can be used to gather information from a set of files to generate an SBOM, along with manipulating SBOMs and analyzing the information in them. It pulls information from recognized file types (such as PE, ELF, or MSI files) contained within a directory structure corresponding to an extracted software package. By default, the information is "surface-level" metadata contained in the files that does not require running the files
 or decompilation.
 
 ## Installation
 
 ### For Users:
+
 1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+
 ```bash
 python -m venv cytrics_venv
 source cytrics_venv/bin/activate
 ```
 
 2. Install Surfactant with pip
+
 ```bash
 pip install surfactant
 ```
 
 ### For Developers:
+
 1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+
 ```bash
 python -m venv cytrics_venv
 source cytrics_venv/bin/activate
 ```
 
 2. Clone sbom-surfactant
+
 ```bash
 git clone git@github.com:LLNL/Surfactant.git
 ```
 
 3. Create an editable surfactant install (changes to code will take effect immediately):
+
 ```bash
 pip install -e .
 ```
 
 To install optional dependencies required for running pytest and pre-commit:
+
 ```bash
 pip install -e ".[test,dev]"
 ```
 
 ## Usage
+
 ### Identify sample file
+
 In order to test out surfactant, you will need a sample file/folder. If you don't have one on hand, you can download and use the portable .zip file from <https://github.com/ShareX/ShareX/releases> or the Linux .tar.gz file from <https://github.com/GMLC-TDC/HELICS/releases>. Alternatively, you can pick a sample from https://lc.llnl.gov/gitlab/cir-software-assurance/unpacker-to-sbom-test-files
 
 ### Build configuration file
+
 A configuration file contains the information about the sample to gather information from. Example JSON configuration files can be found in the examples folder of this repository.
 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\
 **installPrefix**: (optional) where the files in **extractPaths** would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc (Note that even on Windows, Unix style `/` directory separators should be used in the path). If not given then the **extractPaths** will be used as the install paths
 
+#### Create config command
+
+A basic configuration file can be easily built using the `create-config` command. This will take a path as a command line argument and will save a file with the default name of the end directory passed to it as a json file. i.e., `/home/user/Desktop/myfolder` will create `myfolder.json`.
+
+```bash
+$  surfactant create-config [INPUT_PATH]
+```
+
 #### Example configuration file
+
 Lets say you have a .tar.gz file that you want to run surfactant on. For this example, we will be using the HELICS release .tar.gz example. In this scenario, the absolute path for this file is `/home/samples/helics.tar.gz`. Upon extracting this file, we get a helics folder with 4 sub-folders: bin, include, lib64, and share.
+
 ##### Example 1: Simple Configuration File
+
 If we want to include only the folders that contain binary files to analyze, our most basic configuration would be:
+
 ```json
 [
   {
-    "extractPaths": [
-      "/home/samples/helics/bin",
-      "/home/samples/helics/lib64"
-    ]
+    "extractPaths": ["/home/samples/helics/bin", "/home/samples/helics/lib64"]
   }
 ]
 ```
+
 The resulting SBOM would be structured like this:
+
 ```json
 {
-    "software": [
-        {
-          "UUID": "abc1",
-          "fileName": ["helics_binary"],
-          "installPath": ["/home/samples/helics/bin/helics_binary"],
-          "containerPath": null
-        },
-        {
-          "UUID": "abc2",
-          "fileName": ["lib1.so"],
-          "installPath": ["/home/samples/helics/lib64/lib1.so"],
-          "containerPath": null
-        }
-
-    ],
-    "relationships": [
-        {
-          "xUUID": "abc1",
-          "yUUID": "abc2",
-          "relationship": "Uses"
-        }
-    ]
+  "software": [
+    {
+      "UUID": "abc1",
+      "fileName": ["helics_binary"],
+      "installPath": ["/home/samples/helics/bin/helics_binary"],
+      "containerPath": null
+    },
+    {
+      "UUID": "abc2",
+      "fileName": ["lib1.so"],
+      "installPath": ["/home/samples/helics/lib64/lib1.so"],
+      "containerPath": null
+    }
+  ],
+  "relationships": [
+    {
+      "xUUID": "abc1",
+      "yUUID": "abc2",
+      "relationship": "Uses"
+    }
+  ]
 }
 ```
+
 ##### Example 2: Detailed Configuration File
+
 A more detailed configuration file might look like the example below. The resulting SBOM would have a software entry for the helics.tar.gz with a "Contains" relationship to all binaries found to in the extractPaths. Providing the install prefix of `/` and an extractPaths as `/home/samples/helics` will allow to surfactant correctly assign the install paths in the SBOM for binaries in the subfolders as `/bin` and `/lib64`.
+
 ```json
 [
   {
     "archive": "/home/samples/helics.tar.gz",
-    "extractPaths": [
-      "/home/samples/helics"
-    ],
+    "extractPaths": ["/home/samples/helics"],
     "installPrefix": "/"
   }
 ]
 ```
+
 The resulting SBOM would be structured like this:
+
 ```json
 {
-    "software": [
-        {
-          "UUID": "abc0",
-          "fileName": ["helics.tar.gz"],
-          "installPath": null,
-          "containerPath": null
-        },
-        {
-          "UUID": "abc1",
-          "fileName": ["helics_binary"],
-          "installPath": ["/bin/helics_binary"],
-          "containerPath": ["abc0/bin/helics_binary"]
-        },
-        {
-          "UUID": "abc2",
-          "fileName": ["lib1.so"],
-          "installPath": ["/lib64/lib1.so"],
-          "containerPath": ["abc0/lib64/lib1.so"]
-        }
-
-    ],
-    "relationships": [
-        {
-            "xUUID": "abc0",
-            "yUUID": "abc1",
-            "relationship": "Contains"
-        },
-         {
-            "xUUID": "abc0",
-            "yUUID": "abc2",
-            "relationship": "Contains"
-        },
-        {
-            "xUUID": "abc1",
-            "yUUID": "abc2",
-            "relationship": "Uses"
-        }
-    ]
+  "software": [
+    {
+      "UUID": "abc0",
+      "fileName": ["helics.tar.gz"],
+      "installPath": null,
+      "containerPath": null
+    },
+    {
+      "UUID": "abc1",
+      "fileName": ["helics_binary"],
+      "installPath": ["/bin/helics_binary"],
+      "containerPath": ["abc0/bin/helics_binary"]
+    },
+    {
+      "UUID": "abc2",
+      "fileName": ["lib1.so"],
+      "installPath": ["/lib64/lib1.so"],
+      "containerPath": ["abc0/lib64/lib1.so"]
+    }
+  ],
+  "relationships": [
+    {
+      "xUUID": "abc0",
+      "yUUID": "abc1",
+      "relationship": "Contains"
+    },
+    {
+      "xUUID": "abc0",
+      "yUUID": "abc2",
+      "relationship": "Contains"
+    },
+    {
+      "xUUID": "abc1",
+      "yUUID": "abc2",
+      "relationship": "Uses"
+    }
+  ]
 }
 ```
+
 ##### Example 3: Adding Related Binaries
+
 If our sample helics tar.gz file came with a related tar.gz file to install a plugin extension module (extracted into a helics_plugin folder that contains bin and lib64 subfolders), we could add that into the configuration file as well:
+
 ```json
 [
   {
     "archive": "/home/samples/helics.tar.gz",
-    "extractPaths": [
-      "/home/samples/helics"
-    ],
+    "extractPaths": ["/home/samples/helics"],
     "installPrefix": "/"
   },
   {
     "archive": "/home/samples/helics_plugin.tar.gz",
-    "extractPaths": [
-      "/home/samples/helics_plugin"
-    ],
+    "extractPaths": ["/home/samples/helics_plugin"],
     "installPrefix": "/"
   }
 ]
 ```
+
 The resulting SBOM would be structured like this:
+
 ```json
 {
-    "software": [
-        {
-          "UUID": "abc0",
-          "fileName": ["helics.tar.gz"],
-          "installPath": null,
-          "containerPath": null
-        },
-        {
-          "UUID": "abc1",
-          "fileName": ["helics_binary"],
-          "installPath": ["/bin/helics_binary"],
-          "containerPath": ["abc0/bin/helics_binary"]
-        },
-        {
-          "UUID": "abc2",
-          "fileName": ["lib1.so"],
-          "installPath": ["/lib64/lib1.so"],
-          "containerPath": ["abc0/lib64/lib1.so"]
-        },
-        {
-          "UUID": "abc3",
-          "fileName": ["helics_plugin.tar.gz"],
-          "installPath": null,
-          "containerPath": null
-        },
-        {
-          "UUID": "abc4",
-          "fileName": ["helics_plugin"],
-          "installPath": ["/bin/helics_plugin"],
-          "containerPath": ["abc3/bin/helics_plugin"]
-        },
-        {
-          "UUID": "abc5",
-          "fileName": ["lib_plugin.so"],
-          "installPath": ["/lib64/lib_plugin.so"],
-          "containerPath": ["abc3/lib64/lib_plugin.so"]
-        }
-    ],
-    "relationships": [
-        {
-            "xUUID": "abc1",
-            "yUUID": "abc2",
-            "relationship": "Uses"
-        },
-        {
-            "xUUID": "abc4",
-            "yUUID": "abc5",
-            "relationship": "Uses"
-        },
-        {
-            "xUUID": "abc5",
-            "yUUID": "abc2",
-            "relationship": "Uses"
-        },
-        {
-            "xUUID": "abc0",
-            "yUUID": "abc1",
-            "relationship": "Contains"
-        },
-        {
-            "xUUID": "abc0",
-            "yUUID": "abc2",
-            "relationship": "Contains"
-        },
-        {
-            "xUUID": "abc3",
-            "yUUID": "abc4",
-            "relationship": "Contains"
-        },
-        {
-            "xUUID": "abc3",
-            "yUUID": "abc5",
-            "relationship": "Contains"
-        }
-    ]
+  "software": [
+    {
+      "UUID": "abc0",
+      "fileName": ["helics.tar.gz"],
+      "installPath": null,
+      "containerPath": null
+    },
+    {
+      "UUID": "abc1",
+      "fileName": ["helics_binary"],
+      "installPath": ["/bin/helics_binary"],
+      "containerPath": ["abc0/bin/helics_binary"]
+    },
+    {
+      "UUID": "abc2",
+      "fileName": ["lib1.so"],
+      "installPath": ["/lib64/lib1.so"],
+      "containerPath": ["abc0/lib64/lib1.so"]
+    },
+    {
+      "UUID": "abc3",
+      "fileName": ["helics_plugin.tar.gz"],
+      "installPath": null,
+      "containerPath": null
+    },
+    {
+      "UUID": "abc4",
+      "fileName": ["helics_plugin"],
+      "installPath": ["/bin/helics_plugin"],
+      "containerPath": ["abc3/bin/helics_plugin"]
+    },
+    {
+      "UUID": "abc5",
+      "fileName": ["lib_plugin.so"],
+      "installPath": ["/lib64/lib_plugin.so"],
+      "containerPath": ["abc3/lib64/lib_plugin.so"]
+    }
+  ],
+  "relationships": [
+    {
+      "xUUID": "abc1",
+      "yUUID": "abc2",
+      "relationship": "Uses"
+    },
+    {
+      "xUUID": "abc4",
+      "yUUID": "abc5",
+      "relationship": "Uses"
+    },
+    {
+      "xUUID": "abc5",
+      "yUUID": "abc2",
+      "relationship": "Uses"
+    },
+    {
+      "xUUID": "abc0",
+      "yUUID": "abc1",
+      "relationship": "Contains"
+    },
+    {
+      "xUUID": "abc0",
+      "yUUID": "abc2",
+      "relationship": "Contains"
+    },
+    {
+      "xUUID": "abc3",
+      "yUUID": "abc4",
+      "relationship": "Contains"
+    },
+    {
+      "xUUID": "abc3",
+      "yUUID": "abc5",
+      "relationship": "Contains"
+    }
+  ]
 }
 ```
+
 NOTE: These examples have been simplified to show differences in output based on configuration.
 
 ### Run surfactant
+
 ```bash
 $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 ```
+
 **CONFIG_FILE**: (required) the config file created earlier that contains the information on the sample\
 **SBOM OUTPUT**: (required) the desired name of the output file\
 **INPUT_SBOM**: (optional) a base sbom, should be used with care as relationships could be messed up when files are installed on different systems\
@@ -277,36 +305,45 @@ $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 **--help**: (optional) show the help message and exit
 
 ## Understanding the SBOM Output
+
 ### Software
+
 This section contains a list of entries relating to each piece of software found in the sample. Metadata including file size, vendor, version, etc are included in this section along with a uuid to uniquely identify the software entry.
 
 ### Relationships
+
 This section contains information on how each of the software entries in the previous section are linked.
 
 **Uses**: this relationship type means that x software uses y software i.e. y is a helper module to x\
 **Contains**: this relationship type means that x software contains y software (often x software is an installer or archive such as a zip file)
 
 ### Observations:
+
 This section contains information about notable observations about individual software components. This could be vulnerabilities, observed features, etc
 
 ## Merging SBOMs
+
 TODO: Insert documentation on how to merge sboms here
 
 ## Plugins
+
 Detailed information on the plugin system can be found [here](./README-PLUGIN.md).
 
 ## Support
+
 Full user guides for Surfactant are available [online](https://surfactant.readthedocs.io)
 and in the [docs](./docs) directory.
 
 For questions or support, please create a new discussion on GitHub Discussions.
 
 ## Contributing
+
 Contributions are welcome. Bug fixes or minor changes are preferred via a
 pull request to the [Surfactant GitHub repository](https://github.com/LLNL/Surfactant).
 For more information on contributing see the [CONTRIBUTING](./CONTRIBUTING.md) file.
 
 ## License
+
 Surfactant is released under the MIT license. See the [LICENSE](./LICENSE)
 and [NOTICE](./NOTICE) files for details. All new contributions must be made
 under this license.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ A basic configuration file can be easily built using the `create-config` command
 $  surfactant create-config [INPUT_PATH]
 ```
 
+The --output flag can be used to specify the configuration output name. The --install-prefix can be used to specify the install prefix, the default is '/'.
+
+```bash
+$  surfactant create-config [INPUT_PATH] --output new_output.json --install-prefix 'C:/'
+```
+
 #### Example configuration file
 
 Lets say you have a .tar.gz file that you want to run surfactant on. For this example, we will be using the HELICS release .tar.gz example. In this scenario, the absolute path for this file is `/home/samples/helics.tar.gz`. Upon extracting this file, we get a helics folder with 4 sub-folders: bin, include, lib64, and share.

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -11,6 +11,7 @@ import sys
 import click
 from loguru import logger
 
+from surfactant.cmd.createconfig import create_config
 from surfactant.cmd.generate import sbom as generate
 from surfactant.cmd.merge import merge_command
 from surfactant.cmd.stat import stat
@@ -41,6 +42,7 @@ main.add_command(generate)
 main.add_command(version)
 main.add_command(stat)
 main.add_command(merge_command)
+main.add_command(create_config)
 
 if __name__ == "__main__":
     main(log_level="INFO")

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -24,7 +24,7 @@ def create_config(directory, output):
         # If there are no files, add the immediate subdirectories
         for item in starting_directory.iterdir():
             if item.is_dir():
-                extract_paths.append(str(item).replace("\\", "/"))
+                extract_paths.append(item.as_posix())
 
     config_dict = {"extractPaths": extract_paths, "installPrefix": "/"}
     config_out = [config_dict]

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,4 +1,5 @@
 import json
+from loguru import logger
 from pathlib import Path
 
 import click

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -21,24 +21,10 @@ from loguru import logger
 )
 def create_config(directory, output, install_prefix):
     """Create surfactant input configuration file based on input directory."""
-    starting_directory = Path(directory)
-    extract_paths = []
-
-    # Check if there are any files in the directory
-    if any(item.is_file() for item in starting_directory.iterdir()):
-        extract_paths.append(starting_directory.as_posix())
-    else:
-        # If there are no files, add the immediate subdirectories
-        for item in starting_directory.iterdir():
-            if item.is_dir():
-                extract_paths.append(item.as_posix())
-
+    extract_paths = [Path(directory).as_posix()]
     config_dict = {"extractPaths": extract_paths, "installPrefix": install_prefix}
     config_out = [config_dict]
-
-    output_file_name = output or starting_directory.stem + ".json"
-
+    output_file_name = output or Path(directory).stem + ".json"
     with open(output_file_name, "w") as json_file:
         json.dump(config_out, json_file, indent=4)
-
     logger.info(f"Data written to {output_file_name}")

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,8 +1,8 @@
 import json
-from loguru import logger
 from pathlib import Path
 
 import click
+from loguru import logger
 
 
 @click.command()

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+
 import click
 
 
@@ -11,7 +12,6 @@ import click
     type=str,
     help="Output JSON file name, defaults to end of directory string passed as input",
 )
-
 def create_config(directory, output):
     """Create surfactant input configuration file based on input directory."""
     starting_directory = Path(directory)
@@ -35,4 +35,3 @@ def create_config(directory, output):
         json.dump(config_out, json_file, indent=4)
 
     click.echo(f"Data written to {output_file_name}")
-

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,9 +1,7 @@
 import json
 from pathlib import Path
-
 import click
 from loguru import logger
-
 
 @click.command()
 @click.argument("directory", type=click.Path(exists=True))
@@ -13,7 +11,13 @@ from loguru import logger
     type=str,
     help="Output JSON file name, defaults to end of directory string passed as input",
 )
-def create_config(directory, output):
+@click.option(
+    "--install-prefix",
+    type=str,
+    default="/",
+    help="Install prefix to use in the configuration (default: '/')",
+)
+def create_config(directory, output, install_prefix):
     """Create surfactant input configuration file based on input directory."""
     starting_directory = Path(directory)
     extract_paths = []
@@ -27,10 +31,10 @@ def create_config(directory, output):
             if item.is_dir():
                 extract_paths.append(item.as_posix())
 
-    config_dict = {"extractPaths": extract_paths, "installPrefix": "/"}
+    config_dict = {"extractPaths": extract_paths, "installPrefix": install_prefix}
     config_out = [config_dict]
 
-    output_file_name = output or starting_directory.with_suffix(".json")
+    output_file_name = output or starting_directory.stem +".json"
 
     with open(output_file_name, "w") as json_file:
         json.dump(config_out, json_file, indent=4)

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -29,7 +29,7 @@ def create_config(directory, output):
     config_dict = {"extractPaths": extract_paths, "installPrefix": "/"}
     config_out = [config_dict]
 
-    output_file_name = output or starting_directory.stem + ".json"
+    output_file_name = output or starting_directory.with_suffix(".json")
 
     with open(output_file_name, "w") as json_file:
         json.dump(config_out, json_file, indent=4)

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
+
 import click
 from loguru import logger
+
 
 @click.command()
 @click.argument("directory", type=click.Path(exists=True))
@@ -34,7 +36,7 @@ def create_config(directory, output, install_prefix):
     config_dict = {"extractPaths": extract_paths, "installPrefix": install_prefix}
     config_out = [config_dict]
 
-    output_file_name = output or starting_directory.stem +".json"
+    output_file_name = output or starting_directory.stem + ".json"
 
     with open(output_file_name, "w") as json_file:
         json.dump(config_out, json_file, indent=4)

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -34,4 +34,4 @@ def create_config(directory, output):
     with open(output_file_name, "w") as json_file:
         json.dump(config_out, json_file, indent=4)
 
-    click.echo(f"Data written to {output_file_name}")
+    logger.info(f"Data written to {output_file_name}")

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+import click
+
+
+@click.command()
+@click.argument("directory", type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    type=str,
+    help="Output JSON file name, defaults to end of directory string passed as input",
+)
+
+def create_config(directory, output):
+    """Create surfactant input configuration file based on input directory."""
+    starting_directory = Path(directory)
+    extract_paths = []
+
+    # Check if there are any files in the directory
+    if any(item.is_file() for item in starting_directory.iterdir()):
+        extract_paths.append(str(starting_directory).replace("\\", "/"))
+    else:
+        # If there are no files, add the immediate subdirectories
+        for item in starting_directory.iterdir():
+            if item.is_dir():
+                extract_paths.append(str(item).replace("\\", "/"))
+
+    config_dict = {"extractPaths": extract_paths, "installPrefix": "/"}
+    config_out = [config_dict]
+
+    output_file_name = output or starting_directory.stem + ".json"
+
+    with open(output_file_name, "w") as json_file:
+        json.dump(config_out, json_file, indent=4)
+
+    click.echo(f"Data written to {output_file_name}")
+

--- a/surfactant/cmd/createconfig.py
+++ b/surfactant/cmd/createconfig.py
@@ -19,7 +19,7 @@ def create_config(directory, output):
 
     # Check if there are any files in the directory
     if any(item.is_file() for item in starting_directory.iterdir()):
-        extract_paths.append(str(starting_directory).replace("\\", "/"))
+        extract_paths.append(starting_directory.as_posix())
     else:
         # If there are no files, add the immediate subdirectories
         for item in starting_directory.iterdir():


### PR DESCRIPTION
A basic configuration file can be created using the 'create-config' command. This will take a path as a command line argument and will save a file with the default name of the end directory passed to it as a configuration json file.