### PR TITLE
Clean-up warnings when building Python packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ Documentation = "https://surfactant.readthedocs.io/en/latest/"
 "Issue Tracker" = "https://github.com/LLNL/Surfactant/issues"
 "Source Code" = "https://github.com/LLNL/Surfactant"
 
-[tool.setuptools]
-packages =["surfactant"]
+[tool.setuptools.packages.find]
+include = ["surfactant", "surfactant.*"]
 
 [tool.setuptools_scm]
 write_to = "surfactant/_version.py"


### PR DESCRIPTION
Cleans up the warnings about packages being absent from package configuration.

Closes #9