### PR TITLE
Add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
+Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
+If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->
+
+### Summary
+
+<!-- please finish the following statement -->
+
+If merged this pull request will
+
+### Proposed changes
+
+<!-- Describe the highlights of the proposed changes here -->


### PR DESCRIPTION
This change adds a PR template that will pre-populate the description of new PRs.

Resolves #85 