### PR TITLE
CYT-691 added cli command and add, find, edit subcommand stubs

### DIFF
--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -11,6 +11,7 @@ import sys
 import click
 from loguru import logger
 
+from surfactant.cmd.cli import add, edit, find
 from surfactant.cmd.createconfig import create_config
 from surfactant.cmd.generate import sbom as generate
 from surfactant.cmd.merge import merge_command
@@ -38,11 +39,22 @@ def version():
     sys.exit(0)
 
 
+@main.group("cli")
+def cli():
+    """Commandline interface used to modify SBOM entries."""
+
+
+# Main Commands
 main.add_command(generate)
 main.add_command(version)
 main.add_command(stat)
 main.add_command(merge_command)
 main.add_command(create_config)
+
+# CLI Subcommands
+cli.add_command(find)
+cli.add_command(edit)
+cli.add_command(add)
 
 if __name__ == "__main__":
     main(log_level="INFO")

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,0 +1,19 @@
+import click
+
+
+@click.argument("sbom", type=click.File("r"), required=True)
+@click.command("find")
+def find(sbom):
+    "CLI command to find specific entry(s) within a supplied SBOM"
+
+
+@click.argument("sbom", type=click.File("r"), required=True)
+@click.command("edit")
+def edit(sbom):
+    "CLI command to edit specific entry(s) in a supplied SBOM"
+
+
+@click.argument("sbom", type=click.File("r"), required=True)
+@click.command("add")
+def add(sbom):
+    "CLI command to add specific entry(s) to a supplied SBOM"


### PR DESCRIPTION
Added a click cli command group and added the 3 planned subcommands for the cli: find, edit, and add.

This can be tested by installing and running surfactant to see the cli command, surfactant cli will show the available cli subcommands. The stubs will be filled out in subsequent tickets