### PR TITLE
Add 'cyclonedx' short name for CycloneDX output writer

### DIFF
--- a/surfactant/output/cyclonedx_writer.py
+++ b/surfactant/output/cyclonedx_writer.py
@@ -93,6 +93,11 @@ def write_sbom(sbom: SBOM, outfile) -> None:
     outfile.write(outputter.output_as_string())
 
 
+@surfactant.plugin.hookimpl
+def short_name() -> Optional[str]:
+    return "cyclonedx"
+
+
 def convert_system_to_cyclonedx_component(system: System) -> Tuple[str, Component]:
     """Converts a system entry in the SBOM to a CycloneDX Component.
 


### PR DESCRIPTION
### Summary

If merged this pull request will add 'cyclonedx' as the short name for the CycloneDX output writer plugin. Closes #104 

### Proposed changes

- Add 'cyclonedx' short name for CycloneDX output writer plugin
