### PR TITLE
Cyt 688 implement surfactant cli find

### DIFF
--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -6,19 +6,23 @@ from loguru import logger
 
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._sbom import SBOM
+from surfactant.sbomtypes._software import Software
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
 @click.option("--file", is_flag=False, help="File of the entry to find")
-@click.option("--sha256", is_flag=False, help="sha256 hash of the entry to find")
+@click.option("--sha256", is_flag=False, type=str, help="sha256 hash of the entry to find")
+@click.option("--uuid", is_flag=False, type=str, help="uuid of the entry to find")
 @click.option(
     "--installPath",
     is_flag=False,
+    type=str,
     help="Matches all entries with a install path or partial install path match",
 )
 @click.option(
     "--containerPath",
     is_flag=False,
+    type=str,
     help="Matches all entries with a container path or partial container path match",
 )
 @click.option(
@@ -34,26 +38,16 @@ from surfactant.sbomtypes._sbom import SBOM
     help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=surfactant.input_readers.[cytrics|cyclonedx|spdx]_reader",
 )
 @click.command("find")
-def find(sbom, sha256, file, installpath, containerpath, output_format, input_format):
+def find(sbom, output_format, input_format, **kwargs):
     "CLI command to find specific entry(s) within a supplied SBOM"
     pm = get_plugin_manager()
     output_writer = find_io_plugin(pm, output_format, "write_sbom")
     input_reader = find_io_plugin(pm, input_format, "read_sbom")
     in_sbom = input_reader.read_sbom(sbom)
-    out_sbom = SBOM()
-    if sha256:  # Specific hash, no need to check any other params
-        out_sbom.add_software(in_sbom.find_software(sha256))
-    elif file:  # Specific file referenced, only return that entry, other options not neccessary
-        sha256, sha1, md5 = _calculate_hashes(file)
-        out_sbom.add_software(in_sbom.find_software(sha256))
-    else:
-        path_query = {}
-        if installpath:
-            path_query["installPath"] = str(installpath)
-        if containerpath:
-            path_query["containerPath"] = str(containerpath)
-        for sw in in_sbom.find_software_by_path(path_query):
-            out_sbom.add_software(sw)
+
+    # Remove None values
+    filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
+    out_sbom = cli_find().execute(in_sbom, **filtered_kwargs)
     if not out_sbom.software:
         logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
@@ -71,11 +65,109 @@ def add(sbom):
     "CLI command to add specific entry(s) to a supplied SBOM"
 
 
-def _calculate_hashes(file):
-    with open(file, "rb") as f:
-        sha256 = hashlib.sha256(f.read())
-        f.seek(0)
-        sha1 = hashlib.sha1(f.read())
-        f.seek(0)
-        md5 = hashlib.md5(f.read())
-    return sha256.hexdigest(), sha1.hexdigest(), md5.hexdigest()
+class cli_find:
+    """
+    A class that implements the surfactant cli find functionality
+
+    Attributes:
+    match_functions     A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    sbom                A internal record of sbom entries the class adds to as it finds more matches.
+    """
+
+    match_functions: dict
+    sbom: SBOM
+
+    def __init__(self):
+        """Initializes the cli_find class"""
+        self.match_functions = {
+            "sha256": self.match_by_sha256,
+            "file": self.match_by_file,
+            "uuid": self.match_by_uuid,
+            "containerpath": self.match_by_containerPath,
+            "installpath": self.match_by_installPath,
+        }
+        self.sbom = SBOM()
+
+    def execute(self, input_sbom: SBOM, **kwargs):
+        """Executes the main functionality of the cli_find class
+        param: input_sbom   The sbom to find matches within
+        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
+        """
+        for sw in input_sbom.software:
+            match = True
+            for k, v in kwargs.items():
+                if not self.match_functions[k](sw, v):
+                    match = False
+                    break
+            if match:
+                self.sbom.add_software(sw)
+        return self.sbom
+
+    def match_by_sha256(self, entry: Software, sha256: str) -> bool:
+        """Matches sbom entry on sha256 hash
+        param: entry   The software sbom entry to match
+        param: sha256: String value of the desired hash to match
+        returns:       bool, True if a match, False if not
+        """
+        if entry.sha256 == sha256:
+            return True
+        return False
+
+    def match_by_file(self, entry: Software, file) -> bool:
+        """Matches sbom entry on a given file
+        param: entry   The software sbom entry to match
+        param: file:   File to match
+        returns:       bool, True if a match, False if not
+        """
+        sha256, _, _ = self._calculate_hashes(file, sha256=True)
+        return self.match_by_sha256(entry, sha256)
+
+    def match_by_uuid(self, entry: Software, uuid: str) -> bool:
+        """Matches sbom entry on uuid
+        param: entry    The software sbom entry to match
+        param: uuid:    String value of the desired uuid to match
+        returns:        bool, True if a match, False if not
+        """
+        if entry.UUID == uuid:
+            return True
+        return False
+
+    def match_by_containerPath(self, entry: Software, containerPath: str) -> bool:
+        """Matches sbom entry on containerpath. Will match if containerPath is contained in any of the containerPath entries.
+        param: entry            The software sbom entry to match
+        param: containerPath:   String value of the desired containerpath to match
+        returns:                bool, True if a match, False if not
+        """
+        if any(containerPath in p for p in entry.containerPath):
+            return True
+        return False
+
+    def match_by_installPath(self, entry: Software, installPath: str) -> bool:
+        """Matches sbom entry on installpath. Will match if installPath is contained in any of the installPath entries.
+        param: entry            The software sbom entry to match
+        param: installPath:     String value of the desired installPath to match
+        returns:                bool, True if a match, False if not
+        """
+        if any(installPath in p for p in entry.installPath):
+            return True
+        return False
+
+    def _calculate_hashes(self, file, sha256=False, sha1=False, md5=False):
+        """Helper function to calculate hashes on a given file.
+        param: file      The file to calculate hashes on
+        param: sha256:   Bool to decide if sha256 hash should be calculated
+        param: sha1:     Bool to decide if sha1 hash should be calculated
+        param: md5:      Bool to decide if md5 hash should be calculated
+        returns:         str, str, str, Hashes calculated, None for those that aren't calculated
+        """
+        sha256_hash, sha1_hash, md5_hash = None, None, None
+        with open(file, "rb") as f:
+            if sha256:
+                sha256_hash = hashlib.sha256(f.read()).hexdigest()
+                f.seek(0)
+            if sha1:
+                sha1_hash = hashlib.sha1(f.read()).hexdigest()
+                f.seek(0)
+            if md5:
+                md5_hash = hashlib.md5(f.read()).hexdigest()
+        return sha256_hash, sha1_hash, md5_hash

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -6,7 +6,6 @@ from loguru import logger
 
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._sbom import SBOM
-from surfactant.sbomtypes._software import Software
 
 
 @click.argument("sbom", type=click.File("r"), required=True)

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -107,9 +107,7 @@ class cli_find:
                     v, _, _ = self._calculate_hashes(v, sha256=True)
                 else:
                     entry_value = vars(sw)[
-                        self.camel_case_conversions[k]
-                        if k in self.camel_case_conversions
-                        else k
+                        self.camel_case_conversions[k] if k in self.camel_case_conversions else k
                     ]
                 if not self.match_functions[type(entry_value)](entry_value, v):
                     match = False

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -84,9 +84,9 @@ class cli_find:
             str: self.match_single_value,
             list: self.match_array_value,
             dict: self.match_dict_value,
-            float: self.match_none,
-            tuple: self.match_none,
-            type(None): self.match_none,
+            float: self.match_none_or_unhandled,
+            tuple: self.match_none_or_unhandled,
+            type(None): self.match_none_or_unhandled,
         }
         self.camel_case_conversions = {
             "uuid": "UUID",
@@ -121,12 +121,7 @@ class cli_find:
                 if k == "file":
                     entry_value = {"sha256": sw.sha256, "sha1": sw.sha1, "md5": sw.md5}
                 else:
-                    key = self.camel_case_conversions[k] if k in self.camel_case_conversions else k
-                    entry_value = (
-                        vars(sw)[key]
-                        if key in vars(sw)
-                        else logger.error(f"Key {key} not found in SBOM")
-                    )
+                    entry_value = vars(sw)[k] if k in vars(sw) else None
                 if not self.match_functions[type(entry_value)](entry_value, v):
                     match = False
                     break

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,7 +1,8 @@
 import hashlib
 import sys
-from loguru import logger
+
 import click
+from loguru import logger
 
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._sbom import SBOM
@@ -40,9 +41,9 @@ def find(sbom, sha256, file, installpath, containerpath, output_format, input_fo
     input_reader = find_io_plugin(pm, input_format, "read_sbom")
     in_sbom = input_reader.read_sbom(sbom)
     out_sbom = SBOM()
-    if sha256: # Specific hash, no need to check any other params
+    if sha256:  # Specific hash, no need to check any other params
         out_sbom.add_software(in_sbom.find_software(sha256))
-    elif file: # Specific file referenced, only return that entry, other options not neccessary
+    elif file:  # Specific file referenced, only return that entry, other options not neccessary
         sha256, sha1, md5 = _calculate_hashes(file)
         out_sbom.add_software(in_sbom.find_software(sha256))
     else:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -54,6 +54,8 @@ def find(sbom, sha256, file, installpath, containerpath, output_format, input_fo
             path_query["containerPath"] = str(containerpath)
         for sw in in_sbom.find_software_by_path(path_query):
             out_sbom.add_software(sw)
+    if not out_sbom.software:
+        logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
 
 

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,15 +1,15 @@
 import hashlib
 import sys
-
+from loguru import logger
 import click
 
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+from surfactant.sbomtypes._sbom import SBOM
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
 @click.option("--file", is_flag=False, help="File of the entry to find")
 @click.option("--sha256", is_flag=False, help="sha256 hash of the entry to find")
-@click.option("--uuid", is_flag=False, help="UUID of the entry to find")
 @click.option(
     "--installPath",
     is_flag=False,
@@ -33,24 +33,27 @@ from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
     help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=surfactant.input_readers.[cytrics|cyclonedx|spdx]_reader",
 )
 @click.command("find")
-def find(sbom, sha256, file, uuid, installpath, containerpath, output_format, input_format):
+def find(sbom, sha256, file, installpath, containerpath, output_format, input_format):
     "CLI command to find specific entry(s) within a supplied SBOM"
     pm = get_plugin_manager()
     output_writer = find_io_plugin(pm, output_format, "write_sbom")
     input_reader = find_io_plugin(pm, input_format, "read_sbom")
     in_sbom = input_reader.read_sbom(sbom)
-    if file:
-        chunkSize = 65536
-        sha256Gen = hashlib.sha256()
-        with open(file, "rb") as f:
-            while True:
-                data = f.read(chunkSize)
-                if not data:
-                    break
-                sha256Gen.update(data)
-        sha256 = sha256Gen.hexdigest()
-        entry = in_sbom.find_software(sha256)
-        output_writer.write_sbom(entry, sys.stdout)
+    out_sbom = SBOM()
+    if sha256: # Specific hash, no need to check any other params
+        out_sbom.add_software(in_sbom.find_software(sha256))
+    elif file: # Specific file referenced, only return that entry, other options not neccessary
+        sha256, sha1, md5 = _calculate_hashes(file)
+        out_sbom.add_software(in_sbom.find_software(sha256))
+    else:
+        path_query = {}
+        if installpath:
+            path_query["installPath"] = str(installpath)
+        if containerpath:
+            path_query["containerPath"] = str(containerpath)
+        for sw in in_sbom.find_software_by_path(path_query):
+            out_sbom.add_software(sw)
+    output_writer.write_sbom(out_sbom, sys.stdout)
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -63,3 +66,13 @@ def edit(sbom):
 @click.command("add")
 def add(sbom):
     "CLI command to add specific entry(s) to a supplied SBOM"
+
+
+def _calculate_hashes(file):
+    with open(file, "rb") as f:
+        sha256 = hashlib.sha256(f.read())
+        f.seek(0)
+        sha1 = hashlib.sha1(f.read())
+        f.seek(0)
+        md5 = hashlib.md5(f.read())
+    return sha256.hexdigest(), sha1.hexdigest(), md5.hexdigest()

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -28,13 +28,13 @@ from surfactant.sbomtypes._sbom import SBOM
     "--output_format",
     is_flag=False,
     default="surfactant.output.cytrics_writer",
-    help="SBOM output format, options=surfactant.output.[cytrics|csv|spdx|cyclonedx]_writer",
+    help="SBOM output format, options=[cytrics|csv|spdx|cyclonedx]",
 )
 @click.option(
     "--input_format",
     is_flag=False,
     default="surfactant.input_readers.cytrics_reader",
-    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=surfactant.input_readers.[cytrics|cyclonedx|spdx]_reader",
+    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
 )
 @click.command("find")
 def find(sbom, output_format, input_format, **kwargs):

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,10 +1,56 @@
+import hashlib
+import sys
+
 import click
+
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
+@click.option("--file", is_flag=False, help="File of the entry to find")
+@click.option("--sha256", is_flag=False, help="sha256 hash of the entry to find")
+@click.option("--uuid", is_flag=False, help="UUID of the entry to find")
+@click.option(
+    "--installPath",
+    is_flag=False,
+    help="Matches all entries with a install path or partial install path match",
+)
+@click.option(
+    "--containerPath",
+    is_flag=False,
+    help="Matches all entries with a container path or partial container path match",
+)
+@click.option(
+    "--output_format",
+    is_flag=False,
+    default="surfactant.output.cytrics_writer",
+    help="SBOM output format, options=surfactant.output.[cytrics|csv|spdx]_writer",
+)
+@click.option(
+    "--input_format",
+    is_flag=False,
+    default="surfactant.input_readers.cytrics_reader",
+    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=surfactant.input_readers.[cytrics|cyclonedx|spdx]_reader",
+)
 @click.command("find")
-def find(sbom):
+def find(sbom, sha256, file, uuid, installpath, containerpath, output_format, input_format):
     "CLI command to find specific entry(s) within a supplied SBOM"
+    pm = get_plugin_manager()
+    output_writer = find_io_plugin(pm, output_format, "write_sbom")
+    input_reader = find_io_plugin(pm, input_format, "read_sbom")
+    in_sbom = input_reader.read_sbom(sbom)
+    if file:
+        chunkSize = 65536
+        sha256Gen = hashlib.sha256()
+        with open(file, "rb") as f:
+            while True:
+                data = f.read(chunkSize)
+                if not data:
+                    break
+                sha256Gen.update(data)
+        sha256 = sha256Gen.hexdigest()
+        entry = in_sbom.find_software(sha256)
+        output_writer.write_sbom(entry, sys.stdout)
 
 
 @click.argument("sbom", type=click.File("r"), required=True)

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -108,7 +108,7 @@ class cli_find:
                 else:
                     entry_value = vars(sw)[
                         self.camel_case_conversions[k]
-                        if k in self.camel_case_conversions.keys()
+                        if k in self.camel_case_conversions
                         else k
                     ]
                 if not self.match_functions[type(entry_value)](entry_value, v):

--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -61,28 +61,11 @@ class SBOM:
                 return True
         return False
 
-    def find_software(self, sha256: Optional[str]) -> Optional[Software]:
+    def find_software(self, sha256: Optional[str]) -> List[Software]:
         for sw in self.software:
             if sha256 == sw.sha256:
                 return sw
         return None
-
-    def find_software_by_path(self, paths: dict) -> Optional[Software]:
-        matches = []
-        for sw in self.software:
-            all_match = True
-            for pathname, path in paths.items():
-                if pathname == "containerPath":
-                    if not any(path in p for p in sw.containerPath):
-                        all_match = False
-                        break
-                if pathname == "installPath":
-                    if not any(path in p for p in sw.installPath):
-                        all_match = False
-                        break
-            if all_match:
-                matches.append(sw)
-        return matches
 
     def add_software(self, sw: Software) -> None:
         self.software.append(sw)

--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -66,6 +66,24 @@ class SBOM:
             if sha256 == sw.sha256:
                 return sw
         return None
+    def find_software_by_path(self, paths: dict) -> Optional[Software]:
+        matches = []
+        for sw in self.software:
+            all_match = True
+            for pathname, path in paths.items():
+                if pathname == "containerPath":
+                    if not any(path in p for p in sw.containerPath):
+                        all_match = False
+                        break 
+                if pathname == "installPath":
+                    if not any(path in p for p in sw.installPath):
+                        all_match = False
+                        break 
+            if all_match:
+                matches.append(sw)
+        if not matches:
+            logger.error(f"No software matches found for params {paths}")
+        return matches
 
     def add_software(self, sw: Software) -> None:
         self.software.append(sw)

--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -66,6 +66,7 @@ class SBOM:
             if sha256 == sw.sha256:
                 return sw
         return None
+
     def find_software_by_path(self, paths: dict) -> Optional[Software]:
         matches = []
         for sw in self.software:
@@ -74,11 +75,11 @@ class SBOM:
                 if pathname == "containerPath":
                     if not any(path in p for p in sw.containerPath):
                         all_match = False
-                        break 
+                        break
                 if pathname == "installPath":
                     if not any(path in p for p in sw.installPath):
                         all_match = False
-                        break 
+                        break
             if all_match:
                 matches.append(sw)
         if not matches:

--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -82,8 +82,6 @@ class SBOM:
                         break
             if all_match:
                 matches.append(sw)
-        if not matches:
-            logger.error(f"No software matches found for params {paths}")
         return matches
 
     def add_software(self, sw: Software) -> None:

--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -61,7 +61,7 @@ class SBOM:
                 return True
         return False
 
-    def find_software(self, sha256: Optional[str]) -> List[Software]:
+    def find_software(self, sha256: Optional[str]) -> Optional[Software]:
         for sw in self.software:
             if sha256 == sw.sha256:
                 return sw

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -14,65 +14,86 @@ import pytest
 from surfactant.cmd.cli import cli_find
 from surfactant.sbomtypes import SBOM
 
-with open(
-    pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r"
-) as f:
+with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as f:
     in_sbom = SBOM.from_json(f.read())
 
 bad_sbom = SBOM(
-            { "software": [
-                {
-                    "UUID": "477da45b-bb38-450e-93f7-e525aaaa6862",
-                    "name": None,
-                    "size": 16367492,
-                    "fileName": [
-                        "helics.tar.gz"
-                    ],
-                    "installPath": [],
-                    "containerPath": [],
-                    "captureTime": 1689186121,
-                    "version": "",
-                    "vendor": [],
-                    "description": "",
-                    "sha1": "0d21026ee953eeaa31cafef5118be56f46867267",
-                    "sha256": "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
-                    "md5": "5fbf80df5004db2f0ce1f78b524024fe",
-                    "relationshipAssertion": "Unknown",
-                    "comments": "",
-                    "supplementaryFiles": [],
-                    "provenance": None,
-                    "recordedInstitution": "LLNL",
-                    "components": [],
-                    "bad_key": 1.24553
-                }
-            ]
-    })
+    {
+        "software": [
+            {
+                "UUID": "477da45b-bb38-450e-93f7-e525aaaa6862",
+                "name": None,
+                "size": 16367492,
+                "fileName": ["helics.tar.gz"],
+                "installPath": [],
+                "containerPath": [],
+                "captureTime": 1689186121,
+                "version": "",
+                "vendor": [],
+                "description": "",
+                "sha1": "0d21026ee953eeaa31cafef5118be56f46867267",
+                "sha256": "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+                "md5": "5fbf80df5004db2f0ce1f78b524024fe",
+                "relationshipAssertion": "Unknown",
+                "comments": "",
+                "supplementaryFiles": [],
+                "provenance": None,
+                "recordedInstitution": "LLNL",
+                "components": [],
+                "bad_key": 1.24553,
+            }
+        ]
+    }
+)
+
+
 def test_find_by_sha256():
-    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9")
+    out_bom = cli_find().execute(
+        in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    )
     assert len(out_bom.software) == 1
-    assert out_bom.software[0].sha256 == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    assert (
+        out_bom.software[0].sha256
+        == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    )
+
 
 def test_find_by_multiple_hashes():
-    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9", md5="5fbf80df5004db2f0ce1f78b524024fe")
+    out_bom = cli_find().execute(
+        in_sbom,
+        sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+        md5="5fbf80df5004db2f0ce1f78b524024fe",
+    )
     assert len(out_bom.software) == 1
-    assert out_bom.software[0].sha256 == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    assert (
+        out_bom.software[0].sha256
+        == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    )
+
 
 def test_find_by_mismatched_hashes():
-    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9", md5="2ff380e740d2eb09e5d67f6f2cd17636")
+    out_bom = cli_find().execute(
+        in_sbom,
+        sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+        md5="2ff380e740d2eb09e5d67f6f2cd17636",
+    )
     assert len(out_bom.software) == 0
+
 
 def test_find_by_containerPath():
     out_bom = cli_find().execute(in_sbom, containerpath="477da45b-bb38-450e-93f7-e525aaaa6862/")
     assert len(out_bom.software) == 7
-  
+
+
 def test_find_with_malformed_sbom():
-    out_bom = cli_find().execute(bad_sbom, bad_key=1.24553) # Unsupported Type
+    out_bom = cli_find().execute(bad_sbom, bad_key=1.24553)  # Unsupported Type
     assert len(out_bom.software) == 0
-    out_bom = cli_find().execute(bad_sbom, bad_key="testing") # Supported Type
+    out_bom = cli_find().execute(bad_sbom, bad_key="testing")  # Supported Type
     assert len(out_bom.software) == 0
 
+
 def test_find_with_bad_filter():
-    out_bom = cli_find().execute(bad_sbom, bad_filter="testing") # Supported Type
+    out_bom = cli_find().execute(bad_sbom, bad_filter="testing")  # Supported Type
     assert len(out_bom.software) == 0
-    out_bom = cli_find().execute(bad_sbom, bad_filter=1.234) # Unsupported Type
+    out_bom = cli_find().execute(bad_sbom, bad_filter=1.234)  # Unsupported Type
     assert len(out_bom.software) == 0

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import pathlib
+import random
+import string
+
+import pytest
+
+from surfactant.cmd.cli import cli_find
+from surfactant.sbomtypes import SBOM
+
+with open(
+    pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r"
+) as f:
+    in_sbom = SBOM.from_json(f.read())
+
+bad_sbom = SBOM(
+            { "software": [
+                {
+                    "UUID": "477da45b-bb38-450e-93f7-e525aaaa6862",
+                    "name": None,
+                    "size": 16367492,
+                    "fileName": [
+                        "helics.tar.gz"
+                    ],
+                    "installPath": [],
+                    "containerPath": [],
+                    "captureTime": 1689186121,
+                    "version": "",
+                    "vendor": [],
+                    "description": "",
+                    "sha1": "0d21026ee953eeaa31cafef5118be56f46867267",
+                    "sha256": "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+                    "md5": "5fbf80df5004db2f0ce1f78b524024fe",
+                    "relationshipAssertion": "Unknown",
+                    "comments": "",
+                    "supplementaryFiles": [],
+                    "provenance": None,
+                    "recordedInstitution": "LLNL",
+                    "components": [],
+                    "bad_key": 1.24553
+                }
+            ]
+    })
+def test_find_by_sha256():
+    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9")
+    assert len(out_bom.software) == 1
+    assert out_bom.software[0].sha256 == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+
+def test_find_by_multiple_hashes():
+    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9", md5="5fbf80df5004db2f0ce1f78b524024fe")
+    assert len(out_bom.software) == 1
+    assert out_bom.software[0].sha256 == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+
+def test_find_by_mismatched_hashes():
+    out_bom = cli_find().execute(in_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9", md5="2ff380e740d2eb09e5d67f6f2cd17636")
+    assert len(out_bom.software) == 0
+
+def test_find_by_containerPath():
+    out_bom = cli_find().execute(in_sbom, containerpath="477da45b-bb38-450e-93f7-e525aaaa6862/")
+    assert len(out_bom.software) == 7
+  
+def test_find_with_malformed_sbom():
+    out_bom = cli_find().execute(bad_sbom, bad_key=1.24553) # Unsupported Type
+    assert len(out_bom.software) == 0
+    out_bom = cli_find().execute(bad_sbom, bad_key="testing") # Supported Type
+    assert len(out_bom.software) == 0
+
+def test_find_with_bad_filter():
+    out_bom = cli_find().execute(bad_sbom, bad_filter="testing") # Supported Type
+    assert len(out_bom.software) == 0
+    out_bom = cli_find().execute(bad_sbom, bad_filter=1.234) # Unsupported Type
+    assert len(out_bom.software) == 0

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -3,13 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
-import os
 import pathlib
-import random
-import string
-
-import pytest
 
 from surfactant.cmd.cli import cli_find
 from surfactant.sbomtypes import SBOM


### PR DESCRIPTION
### Summary

If merged this pull request will add basic functionality to the surfactant cli find command. It will allow users to filter software entries in their SBOM based on a specific file, sha256 hash, installPath and/or containerPath.

### Proposed changes

No changes, just additions to the surfactant cli find command allowing for searches based on a small subset of features.

### Proposed Usage
Searching for all software entries containing "81983020/ " in the containerPath and "User/Bob/Program Files" in the installPath. Results output stdout, but can be redirected to a json file.
`surfactant cli find --containerPath 81983020/ --installPath "User/Bob/Program Files" sample_sbom.json > subset.json`
If no matches, surfactant will log an error. 

Searching for the entry for a specific file /home/file.msi
`surfactant cli find --file /home/file.msi sample_sbom.json > subset.json`

Searching for a specific sha256 hash:
`surfactant cli find --sha256 897498273497293847923 sample_sbom.json > subset.json`