### PR TITLE
Avoid creating a system object if the UUID already exists (#123)

### DIFF
--- a/surfactant/cmd/merge.py
+++ b/surfactant/cmd/merge.py
@@ -53,14 +53,25 @@ def merge(input_sboms, sbom_outfile, config, output_writer):
 
     rel_graph = construct_relationship_graph(merged_sbom)
     roots = get_roots_check_cycles(rel_graph)
+
+    # Check if provided UUID for a system object already exists to avoid creating a duplicate
+    add_system = True
+    if config and "system" in config:
+        if "UUID" in config["system"]:
+            for s in merged_sbom.systems:
+                if config["system"]["UUID"] == s.UUID:
+                    add_system = False
+                    break
+    # Even if not adding the system, create a dummy/placeholder with the UUID for creating relationships
     system = create_system_object(merged_sbom, config)
-    merged_sbom.systems.append(system)
+    if add_system:
+        merged_sbom.systems.append(system)
 
     # Add a system relationship to each root software/systems entry identified
     for r in roots:
-        merged_sbom.relationships.append(
-            Relationship(xUUID=system["UUID"], yUUID=r, relationship="Includes")
-        )
+        new_relationship = Relationship(xUUID=system.UUID, yUUID=r, relationship="Includes")
+        if new_relationship not in merged_sbom.relationships:
+            merged_sbom.relationships.append(new_relationship)
 
     output_writer.write_sbom(merged_sbom, sbom_outfile)
 
@@ -151,7 +162,7 @@ def create_system_object(sbom: SBOM, config=None) -> System:
     """
 
     system = {}
-    if config:
+    if config and "system" in config:
         system = config["system"]
     # make sure the required fields are present and at least mostly valid
     if ("UUID" not in system) or not sbom.is_valid_uuid4(system["UUID"]):
@@ -171,4 +182,4 @@ def create_system_object(sbom: SBOM, config=None) -> System:
         system["captureStart"] = captureStart
     if "captureEnd" not in system or not system["captureEnd"]:
         system["captureEnd"] = captureEnd
-    return system
+    return System(**system)


### PR DESCRIPTION
### Summary

If merged this pull request will make so that a system object will not be created if the system UUID already to be added already exists, as well as a check to avoid adding relationships to the system that already exist.

Fixes #114.

### Proposed changes
- Add a check to make sure the provided system `UUID` does not already exist before adding a new system object to the merged SBOM
- Add a check to make sure that relationships to the `system` UUID provided don't already exist
- Return `System` object from `create_system_object` function
- Add a check to ensure `"system"` key exists in config for `create_system_object` function