### PR TITLE
Replace deprecated setuptools_scm write_to option with version_file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ Documentation = "https://surfactant.readthedocs.io/en/latest/"
 include = ["surfactant", "surfactant.*"]
 
 [tool.setuptools_scm]
-write_to = "surfactant/_version.py"
+version_file = "surfactant/_version.py"
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]


### PR DESCRIPTION
The `write_tool` configuration option in setuptools_scm is deprecated -- `version_file` should be used instead.

See docs for details: https://setuptools-scm.readthedocs.io/en/latest/config/#setuptools_scm.Configuration