### PR TITLE
Bugfix: merging starRelationships iterates over output SBOM entries

### DIFF
--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -187,7 +187,7 @@ class SBOM:
                 self.observations.append(observation)
         # merge starRelationships
         if sbom_m.starRelationships:
-            for rel in self.starRelationships:
+            for rel in sbom_m.starRelationships:
                 # rewrite UUIDs before doing the search
                 if rel.xUUID in uuid_updates:
                     rel.xUUID = uuid_updates[rel.xUUID]


### PR DESCRIPTION
flake8 flagged line 203 (`self.starRelationships.append(rel)`) as mutating the array that is being iterated over. It looks like the cause of this is actually a bug with iterating over the starRelationships in `self` instead of the input `sbom_m` (see pattern for merging other SBOM array fields).