### PR TITLE
Switch to ruff for several pre-commit checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-extend-ignore = E203,E402,E501,F401,F841

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,13 @@
 exclude: ^(.gitignore|generate_sbom.py|extract_file_info.py|pe_info.py)
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
     hooks:
-      - id: black
-        args: [--config=pyproject.toml, --line-length=100]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
+      # Run the linter
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter
+      - id: ruff-format
   - repo: https://github.com/pycqa/pylint
     rev: v3.0.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,21 @@ version_file = "surfactant/_version.py"
 addopts = ["--import-mode=importlib"]
 pythonpath = "."
 
+[tool.ruff]
+line-length = 100
+indent-width = 4
+
+[tool.ruff.lint]
+# ruff defaults: E4, E7, E9, F
+select = ["E", "F", "B", "I"]
+ignore = ["E501", "F841"]
+# don't fix flake8-bugbear (`B`) violations
+unfixable = ["B"]
+
+# Ignore `E402` import violations in plugin manager
+[tool.ruff.lint.per-file-ignores]
+"surfactant/plugin/manager.py" = ["E402"]
+
 [tool.pylint.messages_control]
 max-line-length = "100"
 good-names-rgxs = "x,y,e,md,sw"

--- a/surfactant/infoextractors/elf_file.py
+++ b/surfactant/infoextractors/elf_file.py
@@ -97,9 +97,9 @@ def extract_elf_info(filename):
                     if note.n_name == "GNU":
                         if note.n_type == "NT_GNU_ABI_TAG":
                             note_info["os"] = note.n_desc.abi_os
-                            note_info["abi"] = (
-                                f"{note.n_desc.abi_major}.{note.n_desc.abi_minor}.{note.n_desc.abi_tiny}"
-                            )
+                            note_info[
+                                "abi"
+                            ] = f"{note.n_desc.abi_major}.{note.n_desc.abi_minor}.{note.n_desc.abi_tiny}"
                         elif note.n_type in ("NT_GNU_BUILD_ID", "NT_GNU_GOLD_VERSION"):
                             note_info["desc"] = note.n_desc
                         else:

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -93,20 +93,20 @@ def extract_pe_info(filename):
             file_details["peMachine"] = pe.FILE_HEADER.Machine
             print("[WARNING] Unknown machine type encountered in PE file header")
     if pe.OPTIONAL_HEADER is not None:
-        file_details["peOperatingSystemVersion"] = (
-            f"{pe.OPTIONAL_HEADER.MajorOperatingSystemVersion}.{pe.OPTIONAL_HEADER.MinorOperatingSystemVersion}"
-        )
-        file_details["peSubsystemVersion"] = (
-            f"{pe.OPTIONAL_HEADER.MajorSubsystemVersion}.{pe.OPTIONAL_HEADER.MinorSubsystemVersion}"
-        )
+        file_details[
+            "peOperatingSystemVersion"
+        ] = f"{pe.OPTIONAL_HEADER.MajorOperatingSystemVersion}.{pe.OPTIONAL_HEADER.MinorOperatingSystemVersion}"
+        file_details[
+            "peSubsystemVersion"
+        ] = f"{pe.OPTIONAL_HEADER.MajorSubsystemVersion}.{pe.OPTIONAL_HEADER.MinorSubsystemVersion}"
         if pe.OPTIONAL_HEADER.Subsystem in pe_subsystem_types:
             file_details["peSubsystem"] = pe_subsystem_types[pe.OPTIONAL_HEADER.Subsystem]
         else:
             file_details["peSubsystem"] = pe.OPTIONAL_HEADER.Subsystem
             print("[WARNING] Unknown Windows Subsystem type encountered in PE file header")
-        file_details["peLinkerVersion"] = (
-            f"{pe.OPTIONAL_HEADER.MajorLinkerVersion}.{pe.OPTIONAL_HEADER.MinorLinkerVersion}"
-        )
+        file_details[
+            "peLinkerVersion"
+        ] = f"{pe.OPTIONAL_HEADER.MajorLinkerVersion}.{pe.OPTIONAL_HEADER.MinorLinkerVersion}"
 
     if import_dir := getattr(pe, "DIRECTORY_ENTRY_IMPORT", None):
         # Imported Symbols
@@ -192,9 +192,9 @@ def extract_pe_info(filename):
 def add_core_assembly_info(asm_dict, asm_info):
     asm_dict["Name"] = asm_info.Name
     asm_dict["Culture"] = asm_info.Culture
-    asm_dict["Version"] = (
-        f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
-    )
+    asm_dict[
+        "Version"
+    ] = f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
     asm_dict["PublicKey"] = (
         asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex") else asm_info.PublicKey
     )

--- a/surfactant/sbomtypes/_software.py
+++ b/surfactant/sbomtypes/_software.py
@@ -54,9 +54,9 @@ class Software:
     sha1: Optional[str] = None
     sha256: Optional[str] = None
     md5: Optional[str] = None
-    relationshipAssertion: Optional[str] = (
-        None  # enum: Unknown, Root, Partial, Known; default=Unknown
-    )
+    relationshipAssertion: Optional[
+        str
+    ] = None  # enum: Unknown, Root, Partial, Known; default=Unknown
     comments: Optional[str] = None
     metadata: Optional[List[object]] = None
     supplementaryFiles: Optional[List[File]] = None


### PR DESCRIPTION
### Summary

If merged this pull request will replace psf/black, isort, and flake8 (+flake8-bugbear) with [ruff](https://github.com/astral-sh/ruff) for the pre-commit checks. There are minor formatting changes with ruff -- likely a change that was in preview for psf/black and recently moved to stable.

For a time comparison when I tested this change on my laptop, using ruff is 10-16x faster than the replaced tools (.04 seconds to check all files). That said... pylint takes 3-4s to run on all files, which is... slow -- ruff is gradually adding those checks, but has a ways to go (with its pylint equivalent rules enabled, it still looks like it will take well under a second to do the same checks).

### Proposed changes

- Replace black, isort, and flake8 pre-commit checks  with ruff
- Update files that have minor formatting changes when using ruff
- gitignore vscode directory
