### PR TITLE
Fix bug with iterating through and adding containers to CycloneDX SBOM

### DIFF
--- a/surfactant/output/cyclonedx_writer.py
+++ b/surfactant/output/cyclonedx_writer.py
@@ -48,7 +48,8 @@ def write_sbom(sbom: SBOM, outfile) -> None:
         # Create CycloneDX Components for every software entry
         # start with software entries that act as containers for other software entries
         if sbom.has_relationship(xUUID=software.UUID, relationship="Contains"):
-            for _, container in convert_software_to_cyclonedx_container_components(software):
+            _, container_list = convert_software_to_cyclonedx_container_components(software)
+            for container in container_list:
                 bom.components.add(container)
         else:
             for parent_uuid, _, file in convert_software_to_cyclonedx_file_components(software):


### PR DESCRIPTION
Found a bug with outputting SBOM in CycloneDX format -- the function returns a tuple rather than a list, so it can't be iterated over with a for loop. The fix moves the function call higher up so that it can unpack the tuple first, then iterate over the contents of the list that belongs to the tuple.

(I think this should be possible to replicate by generating an SBOM using any of the "HELICS" examples that specify an "archive" so that a "Contains" relationship will be created in the resulting SBOM, and then running surfactant generate with the `--output_format cyclonedx`.)