### PR TITLE
fix attribute checks for dnfiles in pe_file infoextractor

### DIFF
--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -190,13 +190,16 @@ def extract_pe_info(filename):
 
 
 def add_core_assembly_info(asm_dict, asm_info):
-    asm_dict["Name"] = asm_info.Name.value
-    asm_dict["Culture"] = asm_info.Culture.value
+    asm_dict["Name"] = (asm_info.Name.value if hasattr(asm_info.Name, "value") else asm_info.Name)
+    asm_dict["Culture"] = (asm_info.Culture.value if hasattr(asm_info.Culture, "value") else asm_info.Culture)
     asm_dict["Version"] = (
         f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
     )
     asm_dict["PublicKey"] = (
-        asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex") else asm_info.PublicKey.value
+        asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex")
+        else (
+           asm_info.PublicKey.value if hasattr(asm_info.PublicKey, "value")
+		)
     )
 
 

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -190,13 +190,13 @@ def extract_pe_info(filename):
 
 
 def add_core_assembly_info(asm_dict, asm_info):
-    asm_dict["Name"] = asm_info.Name
-    asm_dict["Culture"] = asm_info.Culture
+    asm_dict["Name"] = asm_info.Name.value
+    asm_dict["Culture"] = asm_info.Culture.value
     asm_dict["Version"] = (
         f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
     )
     asm_dict["PublicKey"] = (
-        asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex") else asm_info.PublicKey
+        asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex") else asm_info.PublicKey.value
     )
 
 
@@ -236,7 +236,7 @@ def get_assemblyref_info(asmref_info):
     asmref: Dict[str, Any] = {}
     add_core_assembly_info(asmref, asmref_info)
     asmref["HashValue"] = (  # asmref_info.HashValue.hex()
-        asmref_info.HashValue.hex() if hasattr(asmref_info.HashValue, "hex") else asmref_info.HashValue
+        asmref_info.HashValue.value if hasattr(asmref_info.HashValue, "value") else asmref_info.HashValue
     )
     add_assembly_flags_info(asmref, asmref_info)
     return asmref

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -190,17 +190,19 @@ def extract_pe_info(filename):
 
 
 def add_core_assembly_info(asm_dict, asm_info):
-    asm_dict["Name"] = (asm_info.Name.value if hasattr(asm_info.Name, "value") else asm_info.Name)
-    asm_dict["Culture"] = (asm_info.Culture.value if hasattr(asm_info.Culture, "value") else asm_info.Culture)
+    asm_dict["Name"] = asm_info.Name.value if hasattr(asm_info.Name, "value") else asm_info.Name
+    asm_dict["Culture"] = (
+        asm_info.Culture.value if hasattr(asm_info.Culture, "value") else asm_info.Culture
+    )
     asm_dict["Version"] = (
         f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
     )
     asm_dict["PublicKey"] = (
-        asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex")
+        asm_info.PublicKey.hex()
+        if hasattr(asm_info.PublicKey, "hex")
         else (
-           asm_info.PublicKey.value if hasattr(asm_info.PublicKey, "value")
-           else asm_info.PublicKey
-		)
+            asm_info.PublicKey.value if hasattr(asm_info.PublicKey, "value") else asm_info.PublicKey
+        )
     )
 
 

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -199,6 +199,7 @@ def add_core_assembly_info(asm_dict, asm_info):
         asm_info.PublicKey.hex() if hasattr(asm_info.PublicKey, "hex")
         else (
            asm_info.PublicKey.value if hasattr(asm_info.PublicKey, "value")
+           else asm_info.PublicKey
 		)
     )
 

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -235,7 +235,9 @@ def get_assembly_info(asm_info):
 def get_assemblyref_info(asmref_info):
     asmref: Dict[str, Any] = {}
     add_core_assembly_info(asmref, asmref_info)
-    asmref["HashValue"] = asmref_info.HashValue.hex()
+    asmref["HashValue"] = (  # asmref_info.HashValue.hex()
+        asmref_info.HashValue.hex() if hasattr(asmref_info.HashValue, "hex") else asmref_info.HashValue
+    )
     add_assembly_flags_info(asmref, asmref_info)
     return asmref
 


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request adds another check for dnfile attributes. This check is performed at line 199 and needs to check again at line 238 of `surfactant/infoextractors/pe_file.py`.

bug:
```python
File ~/eyeon/yn/lib/python3.10/site-packages/surfactant/infoextractors/pe_file.py:238, in get_assemblyref_info(asmref_info) 
236  asmref: Dict[str, Any] = {}    
237  add_core_assembly_info(asmref, asmref_info)
--> 238  asmref["HashValue"] = asmref_info.HashValue.hex()    
239  add_assembly_flags_info(asmref, asmref_info)
240  return asmref

AttributeError: 'HeapItemBinary' object has no attribute 'hex'
```

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
I have replicated the hex attribute check later in the file, and added `value` field references so we don't get objects returned.

Before:
![image](https://github.com/LLNL/Surfactant/assets/17685289/5b741690-24a3-4356-9bc6-ff31795195c4)

After:
![image](https://github.com/LLNL/Surfactant/assets/17685289/bfb9ff81-4b50-46f0-b8b7-1f8cb0ee9314)
