### PR TITLE
Add EditorConfig to give IDEs hints at how to format various file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines
+[*]
+end_of_line = lf
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Indentation for YAML files for GitHub Actions workflows
+[.github/workflows/*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This adds an [EditorConfig](https://editorconfig.org/) which is recognized by a variety of common IDEs used for software development (including vim), and tells them some basic information on how the files should be formatted.

Resolves #142.