### PR TITLE
Add options to merge command for controlling creation of system entry and type of relationships

### DIFF
--- a/tests/cmd/test_merge.py
+++ b/tests/cmd/test_merge.py
@@ -16,8 +16,7 @@ from surfactant.plugin.manager import get_plugin_manager
 from surfactant.sbomtypes import SBOM, Relationship
 
 # Generate Sample SBOMs
-sbom1 = SBOM.from_json(
-    """{
+sbom1_json = """{
   "software": [
     {
       "UUID": "dd6f7f6b-7c31-4a4a-afef-14678b9942bf",
@@ -68,10 +67,13 @@ sbom1 = SBOM.from_json(
     }
   ]
 }"""
-)
 
-sbom2 = SBOM.from_json(
-    """{
+
+def get_sbom1():
+    return SBOM.from_json(sbom1_json)
+
+
+sbom2_json = """{
         "software": [
             {
             "UUID": "625a07da-7eed-47b9-a0fa-47dcbf76574a",
@@ -124,32 +126,43 @@ sbom2 = SBOM.from_json(
             }
         ]
         }"""
-)
 
-sbom3 = None
-sbom4 = None
 
-config = {
-    "system": {
-        "UUID": "6a0ee431-842f-4963-8867-ef0ef6998003",
-        "name": "",
-        "vendor": None,
-        "captureStart": 1689186121,
-        "captureEnd": 1689186146,
+def get_sbom2():
+    return SBOM.from_json(sbom2_json)
+
+
+def get_config():
+    return {
+        "system": {
+            "UUID": "6a0ee431-842f-4963-8867-ef0ef6998003",
+            "name": "",
+            "vendor": None,
+            "captureStart": 1689186121,
+            "captureEnd": 1689186146,
+        }
     }
-}
 
-with open(
-    pathlib.Path(__file__).parent / "../data/sample_sboms/helics_binaries_sbom.json",
-    "r",
-) as f:
-    sbom3 = SBOM.from_json(f.read())
-with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_libs_sbom.json", "r") as f:
-    sbom4 = SBOM.from_json(f.read())
+
+def get_sbom3():
+    with open(
+        pathlib.Path(__file__).parent / "../data/sample_sboms/helics_binaries_sbom.json",
+        "r",
+    ) as f:
+        return SBOM.from_json(f.read())
+
+
+def get_sbom4():
+    with open(
+        pathlib.Path(__file__).parent / "../data/sample_sboms/helics_libs_sbom.json", "r"
+    ) as f:
+        return SBOM.from_json(f.read())
 
 
 # Test Functions
 def test_simple_merge_method():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
     merged_sbom = sbom1
     merged_sbom.merge(sbom2)
     softwares = sbom1.software
@@ -164,6 +177,8 @@ def test_simple_merge_method():
 
 @pytest.mark.skip(reason="No way of validating this test yet")
 def test_merge_with_circular_dependency():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
     circular_dependency_sbom = sbom1
     circular_dependency_sbom.relationships.add(
         Relationship(
@@ -178,18 +193,20 @@ def test_merge_with_circular_dependency():
     output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
     input_sboms = [circular_dependency_sbom, sbom2]
     with open(outfile_name, "w") as sbom_outfile:
-        merge(input_sboms, sbom_outfile, config, output_writer)
+        merge(input_sboms, sbom_outfile, get_config(), output_writer)
     # TODO add validation checks here
     os.remove(os.path.abspath(outfile_name))
 
 
 @pytest.mark.skip(reason="No way of properly validating this test yet")
 def test_cmdline_merge():
+    sbom3 = get_sbom3()
+    sbom4 = get_sbom4()
     # Test simple merge of two sboms
     outfile_name = generate_filename("test_cmdline_merge")
     pm = get_plugin_manager()
     output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
-    config_file = config
+    config_file = get_config()
     input_sboms = [sbom3, sbom4]
     with open(outfile_name, "w") as sbom_outfile:
         merge(input_sboms, sbom_outfile, config_file, output_writer)
@@ -199,6 +216,137 @@ def test_cmdline_merge():
         generated_sbom = json.loads(j.read())
     with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as j:
         ground_truth_sbom = json.loads(j.read())
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_merge_with_add_system_true():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_merge_with_add_system_true")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    config_file["system"]["UUID"] = "6a0ee431-842f-4963-8867-ef0ef6998003"
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(input_sboms, sbom_outfile, config_file, output_writer, add_system=True)
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    assert generated_sbom["systems"]
+    assert generated_sbom["systems"][0]["UUID"] == config_file["system"]["UUID"]
+
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_merge_with_add_system_false():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_merge_with_add_system_false")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    config_file["system"]["UUID"] = "6a0ee431-842f-4963-8867-ef0ef6998003"
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(input_sboms, sbom_outfile, config_file, output_writer, add_system=False)
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    assert not generated_sbom["systems"]
+
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_merge_with_custom_system_relationship():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_merge_with_custom_system_relationship")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    config_file["systemRelationship"] = "DependsOn"
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(input_sboms, sbom_outfile, config_file, output_writer, add_system=True)
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    for relationship in generated_sbom["relationships"]:
+        if relationship["xUUID"] == config_file["system"]["UUID"]:
+            assert relationship["relationship"] == "DependsOn"
+
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_merge_with_specified_system_uuid():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_merge_with_specified_system_uuid")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    system_uuid = "123e4567-e89b-12d3-a456-426614174000"
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(
+            input_sboms,
+            sbom_outfile,
+            config_file,
+            output_writer,
+            add_system=True,
+            system_uuid=system_uuid,
+        )
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    assert any(system["UUID"] == system_uuid for system in generated_sbom["systems"])
+
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_prevent_orphaned_system_uuid():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_prevent_orphaned_system_uuid")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    # Get rid of the system UUID field from the config file
+    # This will make it try to generate a random UUID, but won't add it since add_system is False
+    del config_file["system"]["UUID"]
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(input_sboms, sbom_outfile, config_file, output_writer, add_system=False)
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    assert not generated_sbom["systems"]
+
+    os.remove(os.path.abspath(outfile_name))
+
+
+def test_add_random_system_uuid():
+    sbom1 = get_sbom1()
+    sbom2 = get_sbom2()
+    outfile_name = generate_filename("test_prevent_orphaned_system_uuid")
+    pm = get_plugin_manager()
+    output_writer = pm.get_plugin("surfactant.output.cytrics_writer")
+    input_sboms = [sbom1, sbom2]
+    config_file = get_config()
+    # Get rid of the system UUID field from the config file
+    # This will make it try to generate a random UUID, but won't add it since add_system is False
+    original_config_system_UUID = config_file["system"]["UUID"]
+    del config_file["system"]["UUID"]
+    with open(outfile_name, "w") as sbom_outfile:
+        merge(input_sboms, sbom_outfile, config_file, output_writer, add_system=True)
+
+    with open(outfile_name, "r") as j:
+        generated_sbom = json.loads(j.read())
+    assert generated_sbom["systems"]
+    # Check that the UUID of the generated system is actually random
+    assert generated_sbom["systems"][0]["UUID"] != original_config_system_UUID
+
     os.remove(os.path.abspath(outfile_name))
 
 


### PR DESCRIPTION
Adds several options to the merge subcommand for controlling if a system entry should be created, and what type should be used for the relationships created.

This enables workflow where relationships to a UUID should be created, but the system UUID was added to e.g. an SBOM repository as part of a separate file.

The more "standard" `Contains` relationship is used instead of the `Includes` relationship that apparently was unique to Surfactant merged SBOMs.

## Changes
* Add option for disabling the creation of a system object
* Add option for specifying what type of relationship should be created for relationships to the system object; use "Contains" as the default type
* Fix a bug where a System SBOM object accessed UUID using subscript notation (`["UUID"]`) instead of as a member variable (`.UUID`)

Resolves #115
Resolves #116