### PR TITLE
pin dnfile version to 0.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "dataclasses_json",
     "pyelftools",
     "pefile",
-    "dnfile",
+    "dnfile==0.14.1",
     "olefile",
     "defusedxml",
     "spdx-tools==0.8.*",


### PR DESCRIPTION
### Summary

`Surfactant generate ...` doesn't run with current dnfile version. Changed it to previous version.

If merged this pull request will pin the dnfile version 0.14.1. Current dnfile version causes breaking changes. 

### Proposed changes

Changed dnfile version to 0.14.1.