### PR TITLE
Implement CLI add subcommand

### DIFF
--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -13,14 +13,14 @@ The **cli find** command allows users to find specific entries within a SBOM. Th
 
 ### Example 1: Find Exact Matches
 ```bash
-surfactant cli find sbom.json --filename foo.exe
+surfactant cli find sbom.json --UUID 123
 {
 "UUID": 123,
 "filename": foo.exe,
 "sha256": <hash>,
 "installPath": ["C:/Users/Test/Downloads/"]
 }
-surfactant cli find --UUID 456
+surfactant cli find --file ../test.exe # File matches are found by hash matching, not filename matches.
 {
 "UUID": 456,
 "filename": test.exe,
@@ -30,37 +30,11 @@ surfactant cli find --UUID 456
 ```
 ### Example 2: Find a Partial Matches
 ```bash
-surfactant cli find --filename *.exe
-{
-"UUID": 123,
-"filename": foo.exe,
-"sha256": <hash>,
-"installPath": ["C:/Users/Test/Downloads/"]
-},
-{
-"UUID": 456,
-"filename": test.exe,
-"sha256": <hash>,
-"installPath": ["C:/Users/Test/Documents/"]
-}
-```
-```bash
 surfactant cli find --installpath C:/Users/Test/Downloads/
 {
 "UUID": 123,
 "filename": foo.exe,
 "sha256": <hash>
-"installPath": ["C:/Users/Test/Downloads/"]
-}
-```
-### Example 3: Find by File
-Note: File matches are found by hash matching, not filename matches.
-```bash
-surfactant cli find --file foo.exe
-{
-"UUID": 123,
-"filename": foo.exe,
-"sha256": <hash>,
 "installPath": ["C:/Users/Test/Downloads/"]
 }
 ```
@@ -71,7 +45,7 @@ The **cli add** command will allow users to easily manually add entries to an SB
 - Add whole new entries to sbom
 
 ```bash
-surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}"
+surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" sbom.json
 ```
 ```bash
 surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -3,7 +3,7 @@ The surfactant cli interface allows users to easily and quickly find, add, and e
 Some functionality we support include:
 - Specify a file to either find, add, or edit it's entry in a given SBOM
 - Fix up path prefixes, i.e. installPath or containerPath
-- Add relationships 
+- Add relationships
 
 ## surfactant cli find
 The **cli find** command allows users to find specific entries within a SBOM. This will allow users to do a few things
@@ -13,14 +13,14 @@ The **cli find** command allows users to find specific entries within a SBOM. Th
 
 ### Example 1: Find Exact Matches
 ```bash
-surfactant cli find sbom.json --filename foo.exe  
-{  
-"UUID": 123,  
-"filename": foo.exe,  
+surfactant cli find sbom.json --filename foo.exe
+{
+"UUID": 123,
+"filename": foo.exe,
 "sha256": <hash>,
-"installPath": ["C:/Users/Test/Downloads/"]  
-}  
-surfactant cli find --UUID 456  
+"installPath": ["C:/Users/Test/Downloads/"]
+}
+surfactant cli find --UUID 456
 {
 "UUID": 456,
 "filename": test.exe,
@@ -30,38 +30,38 @@ surfactant cli find --UUID 456
 ```
 ### Example 2: Find a Partial Matches
 ```bash
-surfactant cli find --filename *.exe  
-{  
-"UUID": 123,  
-"filename": foo.exe,  
+surfactant cli find --filename *.exe
+{
+"UUID": 123,
+"filename": foo.exe,
 "sha256": <hash>,
-"installPath": ["C:/Users/Test/Downloads/"]  
-}, 
-{  
-"UUID": 456,  
-"filename": test.exe,  
+"installPath": ["C:/Users/Test/Downloads/"]
+},
+{
+"UUID": 456,
+"filename": test.exe,
 "sha256": <hash>,
-"installPath": ["C:/Users/Test/Documents/"]  
-} 
+"installPath": ["C:/Users/Test/Documents/"]
+}
 ```
 ```bash
 surfactant cli find --installpath C:/Users/Test/Downloads/
-{  
-"UUID": 123,  
-"filename": foo.exe,  
-"sha256": <hash>  
+{
+"UUID": 123,
+"filename": foo.exe,
+"sha256": <hash>
 "installPath": ["C:/Users/Test/Downloads/"]
 }
 ```
 ### Example 3: Find by File
 Note: File matches are found by hash matching, not filename matches.
 ```bash
-surfactant cli find --file foo.exe  
-{  
-"UUID": 123,  
-"filename": foo.exe,  
+surfactant cli find --file foo.exe
+{
+"UUID": 123,
+"filename": foo.exe,
 "sha256": <hash>,
-"installPath": ["C:/Users/Test/Downloads/"]  
+"installPath": ["C:/Users/Test/Downloads/"]
 }
 ```
 
@@ -71,11 +71,11 @@ The **cli add** command will allow users to easily manually add entries to an SB
 - Add whole new entries to sbom
 
 ```bash
-surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" 
+surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}"
 ```
 ```bash
-surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json 
+surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json
 ```
 ```bash
-surfactant cli add --file test.exe sbom.json 
+surfactant cli add --file test.exe sbom.json
 ```

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,0 +1,81 @@
+# CLI Usage
+The surfactant cli interface allows users to easily and quickly find, add, and edit entires within a given SBOM.
+Some functionality we support include:
+- Specify a file to either find, add, or edit it's entry in a given SBOM
+- Fix up path prefixes, i.e. installPath or containerPath
+- Add relationships 
+
+## surfactant cli find
+The **cli find** command allows users to find specific entries within a SBOM. This will allow users to do a few things
+- Verify entries exist within the sbom
+- Manually inspect one or more related entries with an SBOM for errors or bad formatting
+- Provide a subset of entries to supply to the cli edit or cli add command.
+
+### Example 1: Find Exact Matches
+```bash
+surfactant cli find sbom.json --filename foo.exe  
+{  
+"UUID": 123,  
+"filename": foo.exe,  
+"sha256": <hash>,
+"installPath": ["C:/Users/Test/Downloads/"]  
+}  
+surfactant cli find --UUID 456  
+{
+"UUID": 456,
+"filename": test.exe,
+"sha256": <hash>,
+"installPath": ["C:/Users/Test/Documents/"]
+}
+```
+### Example 2: Find a Partial Matches
+```bash
+surfactant cli find --filename *.exe  
+{  
+"UUID": 123,  
+"filename": foo.exe,  
+"sha256": <hash>,
+"installPath": ["C:/Users/Test/Downloads/"]  
+}, 
+{  
+"UUID": 456,  
+"filename": test.exe,  
+"sha256": <hash>,
+"installPath": ["C:/Users/Test/Documents/"]  
+} 
+```
+```bash
+surfactant cli find --installpath C:/Users/Test/Downloads/
+{  
+"UUID": 123,  
+"filename": foo.exe,  
+"sha256": <hash>  
+"installPath": ["C:/Users/Test/Downloads/"]
+}
+```
+### Example 3: Find by File
+Note: File matches are found by hash matching, not filename matches.
+```bash
+surfactant cli find --file foo.exe  
+{  
+"UUID": 123,  
+"filename": foo.exe,  
+"sha256": <hash>,
+"installPath": ["C:/Users/Test/Downloads/"]  
+}
+```
+
+## surfactant cli add
+The **cli add** command will allow users to easily manually add entries to an SBOM. This command should allow users to do a few things:
+- Add key value pairs to existing SBOM entries
+- Add whole new entries to sbom
+
+```bash
+surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" 
+```
+```bash
+surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json 
+```
+```bash
+surfactant cli add --file test.exe sbom.json 
+```

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -43,13 +43,40 @@ surfactant cli find --installpath C:/Users/Test/Downloads/
 The **cli add** command will allow users to easily add manual entries to an SBOM. This command should allow users to do a few things:
 - Add key value pairs to existing SBOM entries
 - Add whole new entries to the SBOM
-
+- Add new installPaths based on existing containerPaths
+### Adding a relationship
 ```bash
 surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" sbom.json
 ```
+### Example 1: Adding a manual entry
 ```bash
 surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json
 ```
+### Example 2: Adding an entry by file
 ```bash
 surfactant cli add --file test.exe sbom.json
+```
+### Example 3: Creating new installPaths from containerPaths
+```bash
+surfactant cli add --installPath 123/ /bin/ sbom.json
+```
+Our SBOM before the `cli add` command:
+```bash
+{
+"UUID": 456,
+"filename": test.exe,
+"sha256": <hash>
+"installPath": [],
+"containerPath": ["123/helpers/test/exe"]
+}
+```
+Our SBOM after the `cli add` command:
+```bash
+{
+"UUID": 456,
+"filename": test.exe,
+"sha256": <hash>
+"installPath": ["/bin/helpers/test.exe"],
+"containerPath": ["123/helpers/test.exe"]
+}
 ```

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,12 +1,12 @@
 # CLI Usage
-The surfactant cli interface allows users to easily and quickly find, add, and edit entries within a given SBOM.
+The Surfactant CLI interface allows users to easily and quickly find, add, and edit entries within a given SBOM.
 Some functionality we support includes:
-- Specify a file to either find, add, or edit its entry in a given SBOM
+- Specify a file to find, add, or edit its entry in a given SBOM
 - Fix up path prefixes, i.e. installPath or containerPath
 - Add relationships
 
 ## surfactant cli find
-The **cli find** command allows users to find specific entries within a SBOM. This will allow users to do a few things:
+The **cli find** command allows users to find specific entries within a SBOM. This will allow users to:
 - Verify entries exist within the SBOM
 - Manually inspect one or more related entries within a SBOM for errors or bad formatting
 - Provide a subset of entries to supply to the `cli edit` or `cli add` commands.
@@ -40,7 +40,7 @@ surfactant cli find --installpath C:/Users/Test/Downloads/
 ```
 
 ## surfactant cli add
-The **cli add** command will allow users to easily add manual entries to an SBOM. This command should allow users to do a few things:
+The **cli add** command will allow users to easily add manual entries to an SBOM. This command should allow users to:
 - Add key value pairs to existing SBOM entries
 - Add whole new entries to the SBOM
 - Add new installPaths based on existing containerPaths

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -1,15 +1,15 @@
 # CLI Usage
-The surfactant cli interface allows users to easily and quickly find, add, and edit entires within a given SBOM.
-Some functionality we support include:
-- Specify a file to either find, add, or edit it's entry in a given SBOM
+The surfactant cli interface allows users to easily and quickly find, add, and edit entries within a given SBOM.
+Some functionality we support includes:
+- Specify a file to either find, add, or edit its entry in a given SBOM
 - Fix up path prefixes, i.e. installPath or containerPath
 - Add relationships
 
 ## surfactant cli find
-The **cli find** command allows users to find specific entries within a SBOM. This will allow users to do a few things
-- Verify entries exist within the sbom
-- Manually inspect one or more related entries with an SBOM for errors or bad formatting
-- Provide a subset of entries to supply to the cli edit or cli add command.
+The **cli find** command allows users to find specific entries within a SBOM. This will allow users to do a few things:
+- Verify entries exist within the SBOM
+- Manually inspect one or more related entries within a SBOM for errors or bad formatting
+- Provide a subset of entries to supply to the `cli edit` or `cli add` commands.
 
 ### Example 1: Find Exact Matches
 ```bash
@@ -28,7 +28,7 @@ surfactant cli find --file ../test.exe # File matches are found by hash matching
 "installPath": ["C:/Users/Test/Documents/"]
 }
 ```
-### Example 2: Find a Partial Matches
+### Example 2: Find Partial Matches
 ```bash
 surfactant cli find --installpath C:/Users/Test/Downloads/
 {
@@ -40,9 +40,9 @@ surfactant cli find --installpath C:/Users/Test/Downloads/
 ```
 
 ## surfactant cli add
-The **cli add** command will allow users to easily manually add entries to an SBOM. This command should allow users to do a few things:
+The **cli add** command will allow users to easily add manual entries to an SBOM. This command should allow users to do a few things:
 - Add key value pairs to existing SBOM entries
-- Add whole new entries to sbom
+- Add whole new entries to the SBOM
 
 ```bash
 surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" sbom.json

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -175,7 +175,7 @@ class cli_add:
         self.sbom.software.append(Software.from_dict(entry))
 
     def add_installpath(self, prefixes: tuple):
-        cleaned_prefixes = tuple([p.strip("/") for p in prefixes])
+        cleaned_prefixes = tuple([p.rstrip("/") for p in prefixes])
         containerPathPrefix, installPathPrefix = cleaned_prefixes
         for sw in self.sbom.software:
             for path in sw.containerPath:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -84,7 +84,7 @@ def find(sbom, output_format, input_format, **kwargs):
     "--input_format",
     is_flag=False,
     default="surfactant.input_readers.cytrics_reader",
-    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
+    help="SBOM input format, options=[cytrics|cyclonedx|spdx]",
 )
 @click.command("add")
 def add(sbom, output, output_format, input_format, **kwargs):
@@ -117,11 +117,12 @@ def edit(sbom, output_format, input_format, **kwargs):
 
 class cli_add:
     """
-    A class that implements the surfactant cli find functionality
+    A class that implements the surfactant cli add functionality
 
     Attributes:
-    match_functions     A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
-    sbom                An internal record of sbom entries the class adds to as it finds more matches.
+    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
     """
 
     camel_case_conversions: dict
@@ -155,7 +156,7 @@ class cli_add:
 
     def execute(self, input_sbom: SBOM, **kwargs):
         """Executes the main functionality of the cli_find class
-        param: input_sbom   The sbom to find matches within
+        param: input_sbom   The sbom to add entries to
         param: kwargs:      Dictionary of key/value pairs indicating what features to match on
         """
         converted_kwargs = self.handle_kwargs(kwargs)
@@ -191,8 +192,9 @@ class cli_find:
     A class that implements the surfactant cli find functionality
 
     Attributes:
-    match_functions     A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
-    sbom                An internal record of sbom entries the class adds to as it finds more matches.
+    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
     """
 
     match_functions: dict

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -66,13 +66,8 @@ def find(sbom, output_format, input_format, **kwargs):
     "--installPath",
     is_flag=False,
     type=str,
-    help="Adds installPath to add to all entries",
-)
-@click.option(
-    "--containerPath",
-    is_flag=False,
-    type=str,
-    help="Adds containerPath to add to all entries",
+    nargs=2,
+    help="Adds new installPath by finding and replacing a containerPath prefix (1st arg) with a new prefix (2nd arg)",
 )
 @click.option(
     "--output_format",
@@ -135,13 +130,11 @@ class cli_add:
             "relationship": self.add_relationship,
             "file": self.add_file,
             "installPath": self.add_installpath,
-            "containerPath": self.add_containerpath,
             "entry": self.add_entry,
         }
         self.camel_case_conversions = {
             "uuid": "UUID",
             "filename": "fileName",
-            "containerpath": "containerPath",
             "installpath": "installPath",
             "capturetime": "captureTime",
             "relationshipassertion": "relationshipAssertion",
@@ -178,13 +171,12 @@ class cli_add:
     def add_entry(self, entry):
         self.sbom.software.append(Software.from_dict(entry))
 
-    def add_installpath(self, path):
+    def add_installpath(self, prefixes: tuple):
+        containerPathPrefix, installPathPrefix = prefixes
         for sw in self.sbom.software:
-            sw.installPath.append(path)
-
-    def add_containerpath(self, path):
-        for sw in self.sbom.software:
-            sw.containerPath.append(path)
+            for path in sw.containerPath:
+                if containerPathPrefix in path:
+                    sw.installPath.append(path.replace(containerPathPrefix, installPathPrefix))
 
 
 class cli_find:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -162,53 +162,28 @@ class cli_add:
         self.sbom = input_sbom
 
         for key, value in converted_kwargs.items():
-            if key in self.match_functions.keys():
+            if key in self.match_functions:
                 self.match_functions[key](value)
             else:
                 logger.warning(f"Paramter {key} is not supported")
         return self.sbom
 
     def add_relationship(self, value: dict) -> bool:
-        try:
-            self.sbom.add_relationship(Relationship(**value))
-            return True
-        except Exception as e:
-            logger.warning(f"Could not add relationship {value} to SBOM - {e}")
-        return False
+        self.sbom.add_relationship(Relationship(**value))
 
     def add_file(self, path):
-        try:
-            self.sbom.software.append(Software.create_software_from_file(path))
-            return True
-        except Exception as e:
-            logger.warning(f"Could not add entry for file: {path} to SBOM - {e}")
-        return False
+        self.sbom.software.append(Software.create_software_from_file(path))
 
     def add_entry(self, entry):
-        try:
-            self.sbom.software.append(Software.from_dict(entry))
-            return True
-        except Exception as e:
-            logger.warning(f"Could not add entry: {entry} to SBOM - {e}")
-        return False
+        self.sbom.software.append(Software.from_dict(entry))
 
     def add_installpath(self, path):
-        try:
-            for sw in self.sbom.software:
-                sw.installPath.append(path)
-            return True
-        except Exception as e:
-            logger.warning(f"Could not add installPath: {path} to SBOM - {e}")
-        return False
+        for sw in self.sbom.software:
+            sw.installPath.append(path)
 
     def add_containerpath(self, path):
-        try:
-            for sw in self.sbom.software:
-                sw.containerPath.append(path)
-            return True
-        except Exception as e:
-            logger.warning(f"Could not add containerPath: {path} to SBOM - {e}")
-        return False
+        for sw in self.sbom.software:
+            sw.containerPath.append(path)
 
 
 class cli_find:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -175,7 +175,7 @@ class cli_add:
         self.sbom.software.append(Software.from_dict(entry))
 
     def add_installpath(self, prefixes: tuple):
-        cleaned_prefixes = tuple([p.rstrip("/") for p in prefixes])
+        cleaned_prefixes = (p.rstrip("/") for p in prefixes)
         containerPathPrefix, installPathPrefix = cleaned_prefixes
         for sw in self.sbom.software:
             for path in sw.containerPath:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -5,9 +5,9 @@ import click
 from loguru import logger
 
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
-from surfactant.sbomtypes._relationship import Relationship
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -104,6 +104,7 @@ def add(sbom, output_format, input_format, **kwargs):
 def edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
 
+
 class cli_add:
     """
     A class that implements the surfactant cli find functionality
@@ -112,7 +113,7 @@ class cli_add:
     match_functions     A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
     sbom                An internal record of sbom entries the class adds to as it finds more matches.
     """
-    
+
     camel_case_conversions: dict
     match_functions: dict
     sbom: SBOM
@@ -124,7 +125,7 @@ class cli_add:
             "file": self.add_file,
             "installPath": self.add_installpath,
             "containerPath": self.add_containerpath,
-            "entry": self.add_entry
+            "entry": self.add_entry,
         }
         self.camel_case_conversions = {
             "uuid": "UUID",
@@ -156,7 +157,7 @@ class cli_add:
             else:
                 logger.warning(f"Paramter {key} is not supported")
         return self.sbom
-    
+
     def add_relationship(self, value: dict) -> bool:
         try:
             self.sbom.add_relationship(Relationship(**value))
@@ -180,11 +181,11 @@ class cli_add:
         except Exception as e:
             logger.warning(f"Could not add entry: {entry} to SBOM - {e}")
         return False
-    
+
     def add_installpath(self, path):
         try:
             for sw in self.sbom.software:
-                    sw.installPath.append(path)
+                sw.installPath.append(path)
             return True
         except Exception as e:
             logger.warning(f"Could not add installPath: {path} to SBOM - {e}")
@@ -193,13 +194,11 @@ class cli_add:
     def add_containerpath(self, path):
         try:
             for sw in self.sbom.software:
-                    sw.containerPath.append(path)
+                sw.containerPath.append(path)
             return True
         except Exception as e:
             logger.warning(f"Could not add containerPath: {path} to SBOM - {e}")
         return False
-
-
 
 
 class cli_find:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -143,7 +143,7 @@ class cli_add:
         self.sbom = input_sbom
 
         for key, value in converted_kwargs.items():
-            if key == "file": # Do once
+            if key == "file":
                 self.sbom.software.append(Software.create_software_from_file(value))
             elif key == "relationship":
                 self.sbom.add_relationship(Relationship(**value))

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -57,7 +57,10 @@ def find(sbom, output_format, input_format, **kwargs):
 
 @click.argument("sbom", required=True)
 @click.option(
-    "--output", default=None, is_flag=False, help="Specifies the file to output new sbom. Default replaces the input file."
+    "--output",
+    default=None,
+    is_flag=False,
+    help="Specifies the file to output new sbom. Default replaces the input file.",
 )
 @click.option("--file", is_flag=False, help="Adds entry for file to sbom")
 @click.option("--relationship", is_flag=False, type=str, help="Adds relationship to sbom")

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -175,7 +175,8 @@ class cli_add:
         self.sbom.software.append(Software.from_dict(entry))
 
     def add_installpath(self, prefixes: tuple):
-        containerPathPrefix, installPathPrefix = prefixes
+        cleaned_prefixes = tuple([p.strip("/") for p in prefixes])
+        containerPathPrefix, installPathPrefix = cleaned_prefixes
         for sw in self.sbom.software:
             for path in sw.containerPath:
                 if containerPathPrefix in path:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -57,7 +57,7 @@ def find(sbom, output_format, input_format, **kwargs):
 
 @click.argument("sbom", required=True)
 @click.option(
-    "--output", default=None, is_flag=False, help="Specifies the file to output new sbom to"
+    "--output", default=None, is_flag=False, help="Specifies the file to output new sbom. Default replaces the input file."
 )
 @click.option("--file", is_flag=False, help="Adds entry for file to sbom")
 @click.option("--relationship", is_flag=False, type=str, help="Adds relationship to sbom")

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -4,16 +4,19 @@
 # SPDX-License-Identifier: MIT
 
 import pathlib
+
 import pytest
 
 from surfactant.cmd.cli import cli_add, cli_find
 from surfactant.sbomtypes import SBOM, Relationship
+
 
 @pytest.fixture
 def test_sbom():
     with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as f:
         sbom = SBOM.from_json(f.read())
         return sbom
+
 
 bad_sbom = SBOM(
     {

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -143,7 +143,9 @@ def test_add_relationship():
 
 
 def test_add_installpath():
-    installPath = "C:/Users/test/Program Files/test_folder"
-    out_bom = cli_add().execute(in_sbom, installpath=installPath)
+    containerPathPrefix = "477da45b-bb38-450e-93f7-e525aaaa6862/"
+    installPathPrefix = "/bin/"
+    out_bom = cli_add().execute(in_sbom, installpath=(containerPathPrefix, installPathPrefix))
     for sw in out_bom.software:
-        assert installPath in sw.installPath
+        if containerPathPrefix in sw.containerPath:
+            assert installPathPrefix in sw.installPath

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -11,8 +11,8 @@ from surfactant.cmd.cli import cli_add, cli_find
 from surfactant.sbomtypes import SBOM, Relationship
 
 
-@pytest.fixture
-def test_sbom():
+@pytest.fixture(name="test_sbom")
+def fixture_test_sbom():
     with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as f:
         sbom = SBOM.from_json(f.read())
         return sbom

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -5,8 +5,8 @@
 
 import pathlib
 
-from surfactant.cmd.cli import cli_find
-from surfactant.sbomtypes import SBOM
+from surfactant.cmd.cli import cli_find, cli_add
+from surfactant.sbomtypes import SBOM, Relationship
 
 with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as f:
     in_sbom = SBOM.from_json(f.read())
@@ -91,3 +91,58 @@ def test_find_with_bad_filter():
     assert len(out_bom.software) == 0
     out_bom = cli_find().execute(bad_sbom, bad_filter=1.234)  # Unsupported Type
     assert len(out_bom.software) == 0
+
+
+def test_add_by_file():
+    previous_software_len = len(in_sbom.software)
+    out_bom = cli_add().execute(in_sbom, file=pathlib.Path(__file__).parent / "../data/a_out_files/big_m68020.aout")
+    assert len(out_bom.software) == previous_software_len + 1
+    assert (
+        out_bom.software[8].sha256
+        == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
+    )
+    del in_sbom.software[-1]
+
+
+def test_add_entry():
+    entry = {
+      "UUID": "6b50c545-3e07-4aec-bbb0-bae07704143a",
+      "name": "Test Aout File",
+      "size": 4,
+      "fileName": [
+        "big_m68020.aout"
+      ],
+      "installPath": [],
+      "containerPath": [],
+      "captureTime": 1715726918,
+      "sha1": "fbf8688fbe1976b6f324b0028c4b97137ae9139d",
+      "sha256": "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4",
+      "md5": "e8d3808a4e311a4262563f3cb3a31c3e",
+      "comments": "This is a test entry.",
+    }
+    previous_software_len = len(in_sbom.software)
+    out_bom = cli_add().execute(in_sbom, entry=entry)
+    assert len(out_bom.software) == previous_software_len + 1
+    assert (
+        out_bom.software[8].sha256
+        == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
+    )
+    del in_sbom.software[-1]
+
+
+def test_add_relationship():
+    relationship = {
+      "xUUID": "455341bb-2739-4918-9805-e1a93e27e2a4",
+      "yUUID": "e286a415-6c6b-427d-9fe6-d7dbb0486f7d",
+      "relationship": "Uses"
+    }
+    previous_rel_len = len(in_sbom.relationships)
+    out_bom = cli_add().execute(in_sbom, relationship=relationship)
+    assert len(out_bom.relationships) == previous_rel_len + 1
+    in_sbom.relationships.discard(Relationship(**relationship))
+
+def test_add_installpath():
+    installPath = "C:/Users/test/Program Files/test_folder"
+    out_bom = cli_add().execute(in_sbom, installpath=installPath)
+    for sw in out_bom.software:
+        assert installPath in sw.installPath

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from surfactant.cmd.cli import cli_find, cli_add
+from surfactant.cmd.cli import cli_add, cli_find
 from surfactant.sbomtypes import SBOM, Relationship
 
 with open(pathlib.Path(__file__).parent / "../data/sample_sboms/helics_sbom.json", "r") as f:
@@ -95,7 +95,9 @@ def test_find_with_bad_filter():
 
 def test_add_by_file():
     previous_software_len = len(in_sbom.software)
-    out_bom = cli_add().execute(in_sbom, file=pathlib.Path(__file__).parent / "../data/a_out_files/big_m68020.aout")
+    out_bom = cli_add().execute(
+        in_sbom, file=pathlib.Path(__file__).parent / "../data/a_out_files/big_m68020.aout"
+    )
     assert len(out_bom.software) == previous_software_len + 1
     assert (
         out_bom.software[8].sha256
@@ -106,19 +108,17 @@ def test_add_by_file():
 
 def test_add_entry():
     entry = {
-      "UUID": "6b50c545-3e07-4aec-bbb0-bae07704143a",
-      "name": "Test Aout File",
-      "size": 4,
-      "fileName": [
-        "big_m68020.aout"
-      ],
-      "installPath": [],
-      "containerPath": [],
-      "captureTime": 1715726918,
-      "sha1": "fbf8688fbe1976b6f324b0028c4b97137ae9139d",
-      "sha256": "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4",
-      "md5": "e8d3808a4e311a4262563f3cb3a31c3e",
-      "comments": "This is a test entry.",
+        "UUID": "6b50c545-3e07-4aec-bbb0-bae07704143a",
+        "name": "Test Aout File",
+        "size": 4,
+        "fileName": ["big_m68020.aout"],
+        "installPath": [],
+        "containerPath": [],
+        "captureTime": 1715726918,
+        "sha1": "fbf8688fbe1976b6f324b0028c4b97137ae9139d",
+        "sha256": "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4",
+        "md5": "e8d3808a4e311a4262563f3cb3a31c3e",
+        "comments": "This is a test entry.",
     }
     previous_software_len = len(in_sbom.software)
     out_bom = cli_add().execute(in_sbom, entry=entry)
@@ -132,14 +132,15 @@ def test_add_entry():
 
 def test_add_relationship():
     relationship = {
-      "xUUID": "455341bb-2739-4918-9805-e1a93e27e2a4",
-      "yUUID": "e286a415-6c6b-427d-9fe6-d7dbb0486f7d",
-      "relationship": "Uses"
+        "xUUID": "455341bb-2739-4918-9805-e1a93e27e2a4",
+        "yUUID": "e286a415-6c6b-427d-9fe6-d7dbb0486f7d",
+        "relationship": "Uses",
     }
     previous_rel_len = len(in_sbom.relationships)
     out_bom = cli_add().execute(in_sbom, relationship=relationship)
     assert len(out_bom.relationships) == previous_rel_len + 1
     in_sbom.relationships.discard(Relationship(**relationship))
+
 
 def test_add_installpath():
     installPath = "C:/Users/test/Program Files/test_folder"


### PR DESCRIPTION
### Summary

This merge request implements the basic functionality of the surfactant cli add command. 

If merged this pull request will allow users to add details to sboms without having to do so manually. They can add installPaths or containerPaths, add entries directly or by file, and add relationships. In combination with the find command, they can edit subsets of an sbom without using a IDE. 

### Proposed changes

The proposed changes are
- Adding the cli_add class which handles the details of how items are added to an sbom
- Creating the add command function which takes in the command line inputs and sends them to the cli_add class

### Usage
Some examples of usage are listed below

Adds a relationship to the "relationships" key in sbom.json
```bash
surfactant cli add --relationship "{xUUID:"123",yUUID:456, "relationship: "Uses"}" sbom.json
```
Adds a direct entry into the "software" key in sbom.json
```bash
surfactant cli add --entry "{UUID:"123",filename:"test.exe", "sha256": "3423csdlkf13048kj"}" sbom.json
```
Creates an entry for test.exe in the "software" key in sbom.json
```bash
surfactant cli add --file test.exe sbom.json
```
Redirects output to a new file called subset.json
```bash
surfactant cli add --file test.exe --output subset.json sbom.json
```
### Example Workflow with cli find
Say I wanted to add an installPath to a subset of the entries in the sample sbom helics_sbom.json. I could do so with the following steps
```bash
surfactant cli find --uuid 477da45b-bb38-450e-93f7-e525aaaa6862 helics_sbom.json > subset.json
surfactant cli add --installPath "C:\Users\Downloads" subset.json 
surfactant merge helics_sbom.json subset.json final.json
```

Open to suggestions on the workflow as well. 


Resolves CYT-690
