### PR TITLE
Fix: plugins running multiple times on the same file due to symlinks

### DIFF
--- a/surfactant/fileinfo.py
+++ b/surfactant/fileinfo.py
@@ -70,3 +70,25 @@ def calc_file_hashes(filename):
         "sha1": sha1_hash.hexdigest(),
         "md5": md5_hash.hexdigest(),
     }
+
+
+def sha256sum(filename):
+    """Calculate sha256 hash for the file specified. May throw a FileNotFound exception.
+
+    Args:
+        filename (str): Name of file.
+
+    Returns:
+        Optional[str]: The sha256 hash of the file.
+
+    Raises:
+        FileNotFoundError: If the given filename could not be found.
+    """
+    h = sha256()
+    with open(filename, "rb") as f:
+        # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
+        chunk = f.read(h.block_size)
+        while chunk:
+            h.update(chunk)
+            chunk = f.read(h.block_size)
+    return h.hexdigest()


### PR DESCRIPTION
### Summary

If merged this pull request will refactor the logic used for handling symlinks so that plugins do not run multiple times for the same file, along with changing the way symlink file names are added so they don't depend on the user specifying an install prefix.

Plugins will still run multiple times if there are separate files that happen to have identical hashes -- which could cause a similar problem with the cve-bin-tool plugin as this change solves for symlinks. Some plugins might need to gather information from other files relative to the one they are looking at.
1. Should an extra optional argument be added to the info extractor hook to tell the plugin if a file with the same hash has previously been seen, so it can adjust its behavior accordingly?
2. Should a separate info extraction hook be added for duplicate files in different locations?

### Proposed changes

- Refactor symlink handling to prevent plugins from running multiple time on the same file due to symlinks
- Add file name symlinks (+ track them in the metadata section) regardless of the user supplied an install prefix

Resolves #215