### PR TITLE
Recommend pipx for user installation and show how to pip install plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ To install optional dependencies required for running pytest and pre-commit:
 pip install -e ".[test,dev]"
 ```
 
+`pip install` with the `-e` or `--editable` option can also be used to install Surfactant plugins for development.
+
 ## Code of Conduct
 
 All participants in the Surfactant community are expected to follow our [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ pip install -e ".[test,dev]"
 
 `pip install` with the `-e` or `--editable` option can also be used to install Surfactant plugins for development.
 
+```bash
+pip install -e plugins/fuzzyhashes
+```
+
 ## Usage
 
 ### Identify sample file

--- a/README.md
+++ b/README.md
@@ -28,17 +28,39 @@ or decompilation.
 
 ### For Users:
 
-1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+For ease of use, we recommend using [pipx](https://github.com/pypa/pipx) since it transparently handles creating and using Python virtual environments, which helps avoid dependency conflicts with other installed Python apps. Install `pipx` by following [their installation instructions](https://github.com/pypa/pipx#install-pipx).
+
+1. Install Surfactant using `pipx install` (with python >= 3.8)
+
+```bash
+pipx install surfactant
+```
+
+2. Install plugins using `pipx inject surfactant`. As an example, this is how the fuzzy hashing plugin could be installed from a git repository (PyPI package names, local source directories, or wheel files can also be used).
+
+```bash
+pipx inject surfactant git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhashes
+```
+
+If for some reason manually managing virtual environments is desired, the following steps can be used instead:
+
+1. Create a virtual environment with python >= 3.8 and activate it [Optional, but highly recommended over a global install]
 
 ```bash
 python -m venv cytrics_venv
 source cytrics_venv/bin/activate
 ```
 
-2. Install Surfactant with pip
+2. Install Surfactant with `pip install`
 
 ```bash
 pip install surfactant
+```
+
+3. Install plugins using `pip install`. As an example, this is how the fuzzy hashing plugin could be installed from a git repository (PyPI package names, local source directories, or wheel files can also be used).
+
+```bash
+pip install git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhashes
 ```
 
 ### For Developers:
@@ -67,6 +89,8 @@ To install optional dependencies required for running pytest and pre-commit:
 ```bash
 pip install -e ".[test,dev]"
 ```
+
+`pip install` with the `-e` or `--editable` option can also be used to install Surfactant plugins for development.
 
 ## Usage
 
@@ -349,7 +373,7 @@ Details on the merge command can be found in the docs page [here](./docs/basic_u
 ## Plugins
 
 Surfactant supports using plugins to add additional features. For users, installing and enabling a plugin usually just involves
-doing a `pip install` of the plugin.
+doing a `pipx inject surfactant` when using pipx or `pip install` of the plugin if manually managing virtual environments.
 
 Detailed information on configuration options for the plugin system and how to develop new plugins can be found [here](./docs/plugins.md).
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,17 +9,39 @@ and Windows, though it should also work on other operating systems such as FreeB
 
 ### For Users:
 
-1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+For ease of use, we recommend using [pipx](https://github.com/pypa/pipx) since it transparently handles creating and using Python virtual environments, which helps avoid dependency conflicts with other installed Python apps. Install `pipx` by following [their installation instructions](https://github.com/pypa/pipx#install-pipx).
+
+1. Install Surfactant using `pipx install` (with python >= 3.8)
+
+```bash
+pipx install surfactant
+```
+
+2. Install plugins using `pipx inject surfactant`. As an example, this is how the fuzzy hashing plugin could be installed from a git repository (PyPI package names, local source directories, or wheel files can also be used).
+
+```bash
+pipx inject surfactant git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhashes
+```
+
+If for some reason manually managing virtual environments is desired, the following steps can be used instead:
+
+1. Create a virtual environment with python >= 3.8 and activate it [Optional, but highly recommended over a global install]
 
 ```bash
 python -m venv cytrics_venv
 source cytrics_venv/bin/activate
 ```
 
-2. Install Surfactant with pip
+2. Install Surfactant with `pip install`
 
 ```bash
 pip install surfactant
+```
+
+3. Install plugins using `pip install`. As an example, this is how the fuzzy hashing plugin could be installed from a git repository (PyPI package names, local source directories, or wheel files can also be used).
+
+```bash
+pip install git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhashes
 ```
 
 ### For Developers:
@@ -48,6 +70,8 @@ To install optional dependencies required for running pytest and pre-commit:
 ```bash
 pip install -e ".[test,dev]"
 ```
+
+`pip install` with the `-e` or `--editable` option can also be used to install Surfactant plugins for development.
 
 ## Understanding the SBOM Output
 


### PR DESCRIPTION
### Summary

If merged this pull request will update the docs to recommend users install Surfactant with pipx (which hides the manual virtual environment management) and adds an example of installing plugins.

### Proposed changes

- Recommend pipx for user installation
- Add some more detail on how to install plugins

Resolves #204