### PR TITLE
Fix hashlib.md5 error with FIPS-compliant OpenSSL builds

### DIFF
--- a/surfactant/fileinfo.py
+++ b/surfactant/fileinfo.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 import os
 import stat
+import sys
 from hashlib import md5, sha1, sha256
 
 
@@ -54,7 +55,12 @@ def calc_file_hashes(filename):
     """
     sha256_hash = sha256()
     sha1_hash = sha1()
-    md5_hash = md5()
+    # hashlib.md5 usedforsecurity flag was added in Python 3.9
+    if sys.version_info >= (3, 9):
+        # avoid error with FIPS-compliant OpenSSL library builds complaining about md5
+        md5_hash = md5(usedforsecurity=False)
+    else:
+        md5_hash = md5()
     b = bytearray(4096)
     mv = memoryview(b)
     try:


### PR DESCRIPTION
### Summary

If merged this pull request will fix an error that occurs with hashlib.md5 on systems that have a FIPS-compliant OpenSSL library build, by signaling to hashlib.md5 that we aren't using the md5 hash for something that will affect security. Unfortunately, this option only got added to hashlib in Python 3.9, so Python 3.8 users should upgrade to a newer Python version if they encounter the error.

### Proposed changes

- set hashlib.md5 usedforsecurity flag to False

Resolves #220 