### PR TITLE
Add support for user config file for plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,18 @@ Surfactant settings can be changed using the `surfactant config` subcommand, or 
 
 ### Command Line
 
-Using `surfactant config` is very similar to basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, a plugin that includes an entire copy of the original files as part of the generated SBOM might provide an option to specify the format.
+Using `surfactant config` is very similar to the basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, the `core.recorded_institution` option can be used to configure the recorded institution used to identify who the creator of a generated SBOM was.
 
-Setting the configuration option to `base64` could be done using:
+Setting this option to `LLNL` could be done with the following command:
 
 ```bash
-surfactant config include_entire_file.format base64
+surfactant config core.recorded_institution LLNL
 ```
 
 Getting the currently set value for the option would then be done with:
 
 ```bash
-surfactant config include_entire_file.format
+surfactant config core.recorded_institution
 ```
 
 ### Manual Editing
@@ -126,8 +126,8 @@ to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at 
 The file itself is a TOML file, and for the previously mentioned example plugin may look something like this:
 
 ```toml
-[include_entire_file]
-format = "base64"
+[core]
+recorded_institution = "LLNL"
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ recorded_institution = "LLNL"
 
 In order to test out surfactant, you will need a sample file/folder. If you don't have one on hand, you can download and use the portable .zip file from <https://github.com/ShareX/ShareX/releases> or the Linux .tar.gz file from <https://github.com/GMLC-TDC/HELICS/releases>. Alternatively, you can pick a sample from https://lc.llnl.gov/gitlab/cir-software-assurance/unpacker-to-sbom-test-files
 
-### Build sample configuration file
+### Build configuration file for sample
 
-A sample configuration file contains the information about the sample to gather information from. Example JSON sample configuration files can be found in the examples folder of this repository.
+A configuration file for a sample contains the information about the sample to gather information from. Example JSON sample configuration files can be found in the examples folder of this repository.
 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\

--- a/README.md
+++ b/README.md
@@ -96,15 +96,49 @@ pip install -e ".[test,dev]"
 pip install -e plugins/fuzzyhashes
 ```
 
+## Settings
+
+Surfactant settings can be changed using the `surfactant config` subcommand, or by hand editing the settings configuration file (this is not the same as the JSON file used to configure settings for a particular sample that is described later).
+
+### Command Line
+
+Using `surfactant config` is very similar to basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, a plugin that includes an entire copy of the original files as part of the generated SBOM might provide an option to specify the format.
+
+Setting the configuration option to `base64` could be done using:
+
+```bash
+surfactant config include_entire_file.format base64
+```
+
+Getting the currently set value for the option would then be done with:
+
+```bash
+surfactant config include_entire_file.format
+```
+
+### Manual Editing
+
+If desired, the settings config file can also be manually edited. The location of the file will depend on your platform.
+On Unix-like platforms (including macOS), the XDG directory specification is followed and settings will be stored in
+`${XDG_CONFIG_HOME}/surfactant/config.toml`. If the `XDG_CONFIG_HOME` environment variable is not set, the location defaults
+to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at `%APPDATA%\\surfactant\\config.toml`.
+
+The file itself is a TOML file, and for the previously mentioned example plugin may look something like this:
+
+```toml
+[include_entire_file]
+format = "base64"
+```
+
 ## Usage
 
 ### Identify sample file
 
 In order to test out surfactant, you will need a sample file/folder. If you don't have one on hand, you can download and use the portable .zip file from <https://github.com/ShareX/ShareX/releases> or the Linux .tar.gz file from <https://github.com/GMLC-TDC/HELICS/releases>. Alternatively, you can pick a sample from https://lc.llnl.gov/gitlab/cir-software-assurance/unpacker-to-sbom-test-files
 
-### Build configuration file
+### Build sample configuration file
 
-A configuration file contains the information about the sample to gather information from. Example JSON configuration files can be found in the examples folder of this repository.
+A sample configuration file contains the information about the sample to gather information from. Example JSON sample configuration files can be found in the examples folder of this repository.
 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\

--- a/docs/api/config_manager.md
+++ b/docs/api/config_manager.md
@@ -19,9 +19,8 @@ For systems that use `XDG_CONFIG_HOME`, if the environment variable is not set t
 Here is an example of what the configuration file might look like:
 
 ```toml
-[some_plugin]
-format = "base64"
-collect_emails = true
+[core]
+recorded_institution = "LLNL"
 ```
 
 ### Initialization

--- a/docs/api/config_manager.md
+++ b/docs/api/config_manager.md
@@ -1,0 +1,96 @@
+# ConfigManager
+
+The `ConfigManager` class is used to handle settings stored in a configuration file. It supports reading and writing configuration values while preserving formatting and comments, and it caches the configuration to avoid reloading it multiple times during the application's runtime. The underlying config file location is dependent on the operating system, though typically follows the XDG directory specification and respects the `XDG_CONFIG_HOME` environment variable on Unix-like platforms. On Windows, the configuration file is stored in the AppData Roaming folder (`%APPDATA%`).
+
+## Usage
+
+## Configuration File Location
+
+The location of the configuration file varies depending on the platform:
+
+- **Windows**: `%AppData%\surfactant\config.toml`
+- **macOS**: `${XDG_CONFIG_HOME}/surfactant/config.toml`
+- **Linux**: `${XDG_CONFIG_HOME}/surfactant/config.toml`
+
+For systems that use `XDG_CONFIG_HOME`, if the environment variable is not set then the default location is `~/.config`.
+
+## Example Configuration File
+
+Here is an example of what the configuration file might look like:
+
+```toml
+[some_plugin]
+format = "base64"
+collect_emails = true
+```
+
+### Initialization
+
+To initialize the `ConfigManager`, simply import and create an instance:
+
+```python
+from surfactant.configmanager import ConfigManager
+
+config_manager = ConfigManager()
+```
+
+This automatically handles loading a copy of the config file the first time an instance of the ConfigManager is created, effectively making it a snapshot in time of the configuration settings.
+
+### Getting a Value
+
+To retrieve a stored value, use the `get` method:
+
+```python
+value = config_manager.get('section', 'option', fallback='default_value')
+```
+
+- `section`: The section within the configuration file. For plugins this should be the plugin name.
+- `option`: The option within the section.
+- `fallback`: The fallback value if the option is not found.
+
+Alternatively, dictionary-like access for reading is also supported:
+
+```python
+value = config_manager['section']['option']
+```
+
+However, this makes no guarantees that keys will exist and extra error handling **will be required**. If the `section` is not found then `None` is returned -- trying to access nested keys from this will fail. Furthermore, if the `section` does exist, you will need checks to see if a nested key exists before trying to access its value. A more realistic example would be:
+
+```python
+section_config = config_manager['section'] # May return `None`
+value = section_config['option'] if section_config and 'option' in section_config else None
+```
+
+### Setting a Value
+
+To set a value, use the `set` method:
+
+```python
+config_manager.set('section', 'option', 'new_value')
+```
+
+- `section`: The section within the configuration file. For plugins this should be the plugin name.
+- `option`: The option within the section.
+- `value`: The value to set.
+
+NOTE: Most use cases should not need this.
+
+### Saving the Configuration File
+
+The configuration file is automatically saved when you set a value. The file can be manual saved using:
+
+```python
+config_manager._save_config()
+```
+
+NOTE: Most use cases should not need this.
+
+### Loading the Configuration File
+
+The configuration file can be reloaded using:
+
+```python
+config_manager._load_config()
+```
+
+NOTE: Most use cases should not need this.

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -9,18 +9,18 @@ Surfactant settings can be changed using the `surfactant config` subcommand, or 
 
 ### Command Line
 
-Using `surfactant config` is very similar to basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, a plugin that includes an entire copy of the original files as part of the generated SBOM might provide an option to specify the format.
+Using `surfactant config` is very similar to the basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, the `core.recorded_institution` option can be used to configure the recorded institution used to identify who the creator of a generated SBOM was.
 
-Setting the configuration option to `base64` could be done using:
+Setting this option to `LLNL` could be done with the following command:
 
 ```bash
-surfactant config include_entire_file.format base64
+surfactant config core.recorded_institution LLNL
 ```
 
 Getting the currently set value for the option would then be done with:
 
 ```bash
-surfactant config include_entire_file.format
+surfactant config core.recorded_institution
 ```
 
 ### Manual Editing
@@ -33,8 +33,8 @@ to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at 
 The file itself is a TOML file, and for the previously mentioned example plugin may look something like this:
 
 ```toml
-[include_entire_file]
-format = "base64"
+[core]
+recorded_institution = "LLNL"
 ```
 
 ## Build sample configuration file

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1,12 +1,45 @@
 # Configuration Files
 
 There are several files for configuring different aspects of Surfactant functionality based on the subcommand used.
-This page currently describes the format for the file used to generate an SBOM, but will eventually cover other
-configuration files as well.
+This page currently describes sample configuration files, and the Surfactant settings configuration file. The sample configuration file is used to generate an SBOM for a particular software/firmware sample, and will be the most frequently written by users. The Surfactant settings configuration file is used to turn on and off various Surfactant features, including settings for controlling functionality in Surfactant plugins.
 
-## Build configuration file
+## Settings Configuration File
 
-A configuration file contains the information about the sample to gather information from. Example JSON configuration files can be found in the examples folder of this repository.
+Surfactant settings can be changed using the `surfactant config` subcommand, or by hand editing the settings configuration file (this is not the same as the JSON file used to configure settings for a particular sample that is described later).
+
+### Command Line
+
+Using `surfactant config` is very similar to basic use of `git config`. The key whose value is being accessed will be in the form `section.option` where `section` is typically a plugin name or `core`, and `option` is the option to set. As an example, a plugin that includes an entire copy of the original files as part of the generated SBOM might provide an option to specify the format.
+
+Setting the configuration option to `base64` could be done using:
+
+```bash
+surfactant config include_entire_file.format base64
+```
+
+Getting the currently set value for the option would then be done with:
+
+```bash
+surfactant config include_entire_file.format
+```
+
+### Manual Editing
+
+If desired, the settings config file can also be manually edited. The location of the file will depend on your platform.
+On Unix-like platforms (including macOS), the XDG directory specification is followed and settings will be stored in
+`${XDG_CONFIG_HOME}/surfactant/config.toml`. If the `XDG_CONFIG_HOME` environment variable is not set, the location defaults
+to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at `%APPDATA%\\surfactant\\config.toml`.
+
+The file itself is a TOML file, and for the previously mentioned example plugin may look something like this:
+
+```toml
+[include_entire_file]
+format = "base64"
+```
+
+## Build sample configuration file
+
+A sample configuration file contains the information about the sample to gather information from. Example JSON sample configuration files can be found in the examples folder of this repository.
 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dependencies = [
     "click==8.*",
     "javatools>=1.6,==1.*",
     "loguru==0.7.*",
-    "flask==3.*"
+    "flask==3.*",
+    "tomlkit==0.13.*",
 ]
 dynamic = ["version"]
 

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -12,6 +12,7 @@ import click
 from loguru import logger
 
 from surfactant.cmd.cli import add, edit, find
+from surfactant.cmd.config import config
 from surfactant.cmd.createconfig import create_config
 from surfactant.cmd.generate import sbom as generate
 from surfactant.cmd.merge import merge_command
@@ -55,6 +56,7 @@ def cli():
 # Main Commands
 main.add_command(generate)
 main.add_command(version)
+main.add_command(config)
 main.add_command(stat)
 main.add_command(merge_command)
 main.add_command(create_config)

--- a/surfactant/cmd/config.py
+++ b/surfactant/cmd/config.py
@@ -1,0 +1,51 @@
+from typing import List, Optional
+
+import click
+
+from surfactant.configmanager import ConfigManager
+
+
+@click.command("config")
+@click.argument("key", required=True)
+@click.argument("values", nargs=-1)
+def config(key: str, values: Optional[List[str]]):
+    """Get or set a configuration value.
+
+    If only KEY is provided, the current value is displayed.
+    If both KEY and one or more VALUES are provided, the configuration value is set.
+    KEY should be in the format 'section.option'.
+    """
+    config_manager = ConfigManager()
+
+    if not values:
+        # Get the configuration value
+        try:
+            section, option = key.split(".", 1)
+        except ValueError as err:
+            raise SystemExit("Invalid KEY given. Is it in the format 'section.option'?") from err
+        result = config_manager.get(section, option)
+        if result is None:
+            click.echo(f"Configuration '{key}' not found.")
+        else:
+            click.echo(f"{key} = {result}")
+    else:
+        # Set the configuration value
+        # Convert 'true' and 'false' strings to boolean
+        converted_values = []
+        for value in values:
+            if value.lower() == "true":
+                converted_values.append(True)
+            elif value.lower() == "false":
+                converted_values.append(False)
+            else:
+                converted_values.append(value)
+
+        # If there's only one value, store it as a single value, otherwise store as a list
+        final_value = converted_values[0] if len(converted_values) == 1 else converted_values
+
+        try:
+            section, option = key.split(".", 1)
+        except ValueError as err:
+            raise SystemExit("Invalid KEY given. Is it in the format 'section.option'?") from err
+        config_manager.set(section, option, final_value)
+        click.echo(f"Configuration '{key}' set to '{final_value}'.")

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import queue
 import re
-from typing import Dict, List, Any, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 from loguru import logger

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -7,12 +7,13 @@ import os
 import pathlib
 import queue
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Any, Optional, Tuple, Union
 
 import click
 from loguru import logger
 
 from surfactant import ContextEntry
+from surfactant.configmanager import ConfigManager
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.relationships import parse_relationships
 from surfactant.sbomtypes import SBOM, Software
@@ -143,6 +144,20 @@ def warn_if_hash_collision(soft1: Optional[Software], soft2: Optional[Software])
         )
 
 
+def get_default_from_config(option: str, fallback: Optional[Any] = None) -> Any:
+    """Retrive a core config option for use as default argument value.
+
+    Args:
+        option (str): The core config option to get.
+        fallback (Optional[Any]): The fallback value if the option is not found.
+
+    Returns:
+            Any: The configuration value or 'NoneType' if the key doesn't exist.
+    """
+    config_manager = ConfigManager()
+    return config_manager.get("core", option, fallback=fallback)
+
+
 @click.command("generate")
 @click.argument(
     "config_file",
@@ -176,13 +191,13 @@ def warn_if_hash_collision(soft1: Optional[Software], soft2: Optional[Software])
 @click.option(
     "--recorded_institution",
     is_flag=False,
-    default="LLNL",
+    default=get_default_from_config("recorded_institution"),
     help="Name of user's institution",
 )
 @click.option(
     "--output_format",
     is_flag=False,
-    default="surfactant.output.cytrics_writer",
+    default=get_default_from_config("output_format", fallback="surfactant.output.cytrics_writer"),
     help="SBOM output format, see --list-output-formats for list of options; default is CyTRICS",
 )
 @click.option(
@@ -220,7 +235,7 @@ def sbom(
 ):
     """Generate a sbom configured in CONFIG_FILE and output to SBOM_OUTPUT.
 
-    An optional INPUT_SBOM can be supplied to use as a base for subsequent operations
+    An optional INPUT_SBOM can be supplied to use as a base for subsequent operations.
     """
 
     pm = get_plugin_manager()

--- a/surfactant/configmanager.py
+++ b/surfactant/configmanager.py
@@ -1,0 +1,142 @@
+import os
+import platform
+from pathlib import Path
+from threading import Lock
+from typing import Any, Optional, Union
+
+import tomlkit
+
+
+class ConfigManager:
+    """A configuration manager for handling settings stored in a configuration file. The
+    configuration manager internally caches a copy of the loaded configuration file, so
+    external changes won't affect the setting value while a program is running.
+
+    Attributes:
+        app_name (str): The name of the application. (Default: 'surfactant')
+        config_dir (Optional[Path]): The directory where the configuration file is stored.
+        config (tomlkit.document): The configuration document loaded by tomlkit. Preserves formatting and comments.
+        config_file_path (Path): The path to the configuration file.
+    """
+
+    _instances = {}
+    _lock = Lock()
+
+    def __new__(
+        cls, app_name: str = "surfactant", config_dir: Optional[Union[str, Path]] = None
+    ) -> "ConfigManager":
+        """Manage singleton configuration manager for each unique application name.
+
+        Args:
+            app_name (str): The name of the application. (Default: 'surfactant')
+            config_dir (Optional[Union[str, Path]]): The directory where the application configuration is stored.
+
+        Returns:
+            ConfigManager: The singleton instance of the configuration manager for the given application name.
+        """
+        with cls._lock:
+            if app_name not in cls._instances:
+                instance = super(ConfigManager, cls).__new__(cls)
+                instance._initialized = False
+                cls._instances[app_name] = instance
+            return cls._instances[app_name]
+
+    def __init__(
+        self, app_name: str = "surfactant", config_dir: Optional[Union[str, Path]] = None
+    ) -> None:
+        """Initializes the configuration manager.
+
+        Args:
+            app_name (str): The name of the application. (Default: 'surfactant')
+            config_dir (Optional[Union[str, Path]]): The directory where the application configuration is stored.
+        """
+        if self._initialized:
+            return
+        self._initialized = True
+
+        self.app_name = app_name
+        self.config_dir = Path(config_dir) / app_name if config_dir else None
+        self.config = tomlkit.document()
+        self.config_file_path = self._get_config_file_path()
+        self._load_config()
+
+    def _get_config_file_path(self) -> Path:
+        """Determines the path to the configuration file.
+
+        Returns:
+            Path: The path to the configuration file.
+        """
+        if self.config_dir:
+            config_dir = Path(self.config_dir)
+        else:
+            if platform.system() == "Windows":
+                config_dir = Path(os.getenv("APPDATA", os.path.expanduser("~\\AppData\\Roaming")))
+            else:
+                config_dir = Path(os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config")))
+            config_dir = config_dir / self.app_name
+        return config_dir / "config.toml"
+
+    def _load_config(self) -> None:
+        """Loads the configuration from the configuration file."""
+        if self.config_file_path.exists():
+            with open(self.config_file_path, "r") as configfile:
+                self.config = tomlkit.parse(configfile.read())
+
+    def get(self, section: str, option: str, fallback: Optional[Any] = None) -> Any:
+        """Gets a configuration value.
+
+        Args:
+            section (str): The section within the configuration file.
+            option (str): The option within the section.
+            fallback (Optional[Any]): The fallback value if the option is not found.
+
+        Returns:
+            Any: The configuration value or the fallback value.
+        """
+        return self.config.get(section, {}).get(option, fallback)
+
+    def set(self, section: str, option: str, value: Any) -> None:
+        """Sets a configuration value.
+
+        Args:
+            section (str): The section  within the configuration file.
+            option (str): The option within the section.
+            value (Any): The value to set.
+        """
+        if section not in self.config:
+            self.config[section] = tomlkit.table()
+        self.config[section][option] = value
+        self._save_config()
+
+    def _save_config(self) -> None:
+        """Saves the configuration to the configuration file."""
+        if not self.config_file_path.exists():
+            self.config_file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config_file_path, "w") as configfile:
+            configfile.write(tomlkit.dumps(self.config))
+
+    def __getitem__(self, key: str) -> Any:
+        """Enables dictionary-like syntax for accessing configuration settings.
+        NOTE: Remember to check that the value returned is not 'None' before
+        trying to access nested keys.
+
+        Args:
+            key (str): The key for accessing a TOML value or table.
+
+        Returns:
+            Any: The configuration value or 'NoneType' if the key doesn't exist.
+        """
+        if key not in self.config:
+            return None
+        return self.config[key]
+
+    @classmethod
+    def delete_instance(cls, app_name: str) -> None:
+        """Deletes the singleton instance for the given application name.
+
+        Args:
+            app_name (str): The name of the application.
+        """
+        with cls._lock:
+            if app_name in cls._instances:
+                del cls._instances[app_name]

--- a/tests/config/test_configmanager.py
+++ b/tests/config/test_configmanager.py
@@ -1,0 +1,109 @@
+import os
+import platform
+from pathlib import Path
+
+import pytest
+
+from surfactant.configmanager import ConfigManager
+
+
+@pytest.fixture(name="config_manager")
+def fixture_config_manager(tmp_path):
+    # Use the tmp_path fixture for the temporary directory
+    config_manager = ConfigManager(app_name="testapp", config_dir=tmp_path)
+    yield config_manager
+    # Cleanup after test
+    ConfigManager.delete_instance("testapp")
+
+
+def test_singleton(config_manager):
+    config_manager2 = ConfigManager(app_name="testapp")
+    assert config_manager is config_manager2
+
+
+def test_set_and_get(config_manager):
+    config_manager.set("Settings", "theme", "dark")
+    theme = config_manager.get("Settings", "theme")
+    assert theme == "dark"
+
+
+def test_set_and_getitem(config_manager):
+    config_manager.set("Settings", "theme", "dark")
+    theme = config_manager["Settings"]["theme"]
+    assert theme == "dark"
+
+
+def test_createinstance_and_getitem(config_manager):
+    config_manager.set("Settings", "theme", "dark")
+    # ConfigManager instance accessed will be the same as the one created in the test fixture
+    # so that the set value above will be present for testing
+    settings_config = ConfigManager(app_name="testapp")["Settings"]
+    assert settings_config
+    assert "theme" in settings_config  # pylint: disable=unsupported-membership-test
+    assert settings_config["theme"] == "dark"  # pylint: disable=unsubscriptable-object
+
+
+def test_get_with_fallback(config_manager):
+    fallback_value = "light"
+    theme = config_manager.get("Settings", "theme", fallback=fallback_value)
+    assert theme == fallback_value
+
+
+def test_config_file_creation(config_manager):
+    config_manager.set("Settings", "theme", "dark")
+    assert config_manager.config_file_path.exists()
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Test specific to Windows platform")
+def test_windows_config_path():
+    config_manager = ConfigManager(app_name="testapp")
+    config_path = config_manager._get_config_file_path()  # pylint: disable=protected-access
+    expected_config_dir = Path(os.getenv("APPDATA", str(Path("~\\AppData\\Roaming").expanduser())))
+    assert expected_config_dir in config_path.parents
+    # delete instance so other tests don't accidentally use it
+    config_manager.delete_instance("testapp")
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Test specific to Unix-like platforms")
+def test_unix_config_path():
+    config_manager = ConfigManager(app_name="testapp")
+    config_path = config_manager._get_config_file_path()  # pylint: disable=protected-access
+    expected_config_dir = Path(os.getenv("XDG_CONFIG_HOME", str(Path("~/.config").expanduser())))
+    assert expected_config_dir in config_path.parents
+    # delete instance so other tests don't accidentally use it
+    config_manager.delete_instance("testapp")
+
+
+def test_preserve_comments(config_manager):
+    # Create a config file with some value and add in a comment line
+    config_manager.set("Settings", "theme", "dark")
+    with open(config_manager.config_file_path, "a") as configfile:
+        configfile.write("\n# This is a comment\n")
+    # Force reload of cached config in the ConfigManager
+    config_manager._load_config()  # pylint: disable=protected-access
+    assert config_manager.get("Settings", "theme") == "dark"
+
+    # Set a new value to make ConfigManager to save an updated config file
+    config_manager.set("Settings", "language", "en")
+    with open(config_manager.config_file_path, "r") as configfile:
+        content = configfile.read()
+    assert "# This is a comment" in content
+
+
+def test_multiple_instances(tmp_path):
+    # Make sure two separate config managers can more or less co-exist peacefully
+    config_manager1 = ConfigManager(app_name="testapp1", config_dir=tmp_path)
+    config_manager2 = ConfigManager(app_name="testapp2", config_dir=tmp_path)
+    config_manager1.set("Settings", "theme", "dark")
+    config_manager2.set("Settings", "theme", "light")
+    assert config_manager1.get("Settings", "theme") == "dark"
+    assert config_manager2.get("Settings", "theme") == "light"
+    assert config_manager1.config_file_path.exists()
+    assert config_manager2.config_file_path.exists()
+    assert config_manager1.config_file_path != config_manager2.config_file_path
+    ConfigManager.delete_instance("testapp1")
+    ConfigManager.delete_instance("testapp2")
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
### Summary

If merged this pull request will add support for a user config file that can be used to control plugin settings, and a new `config` subcommand that is modeled after `git config` for getting and setting config options.

Partly addresses #100 -- does not add a way to specify settings via the command line. For plugin config options supported, I think we will have developers include a list of options in their docstrings.

### Proposed changes

- Add ConfigManager that can be used by Surfactant plugins to support user configuration options, stored in a standard location in the user's home directory
- Add a `config` subcommand based on `git config` that can be used to modify the configuration file from the command line
- Add tests for the ConfigManager class
- Add documentation on how to set/get configuration options, from both a user and developer perspective
