### PR TITLE
Add support for extract paths being files

### DIFF
--- a/surfactant/infoextractors/mach_o_file.py
+++ b/surfactant/infoextractors/mach_o_file.py
@@ -28,8 +28,7 @@ __include_signature_content = __config_manager.get("macho", "include_signature_c
 
 
 def supports_file(filetype) -> bool:
-    # TODO: It could be decided whether to keep it this way or separate into cases
-    return "MACHO" in filetype  # Covers MACHOFAT, MACHOFAT64, MACHO32, MACHO64
+    return filetype in ("MACHOFAT", "MACHOFAT64", "MACHO32", "MACHO64")
 
 
 @surfactant.plugin.hookimpl

--- a/surfactant/sbomtypes/_software.py
+++ b/surfactant/sbomtypes/_software.py
@@ -153,3 +153,22 @@ class Software:
                                 current_arr.append(new_value)
 
         return self.UUID, sw.UUID
+
+    @staticmethod
+    def check_for_hash_collision(soft1: Optional[Software], soft2: Optional[Software]) -> bool:
+        if not soft1 or not soft2:
+            return False
+        # A hash collision occurs if one or more but less than all hashes match or
+        # any hash matches but the filesize is different
+        collision = False
+        if soft1.sha256 == soft2.sha256 or soft1.sha1 == soft2.sha1 or soft1.md5 == soft2.md5:
+            # Hashes can be None; make sure they aren't before checking for inequality
+            if soft1.sha256 and soft2.sha256 and soft1.sha256 != soft2.sha256:
+                collision = True
+            elif soft1.sha1 and soft2.sha1 and soft1.sha1 != soft2.sha1:
+                collision = True
+            elif soft1.md5 and soft2.md5 and soft1.md5 != soft2.md5:
+                collision = True
+            elif soft1.size != soft2.size:
+                collision = True
+        return collision


### PR DESCRIPTION
### Summary

<!-- please finish the following statement -->

If merged this pull request will allow extract paths given in a specimen config file to be a file.

### Proposed changes

- Allow extract paths to be individual files (os.walk ignores it, so it had to be a separate case)
- Refactor some of the code for adding entries and determining the install prefix into separate functions to reduce duplicate code
- Add code to handle some corner cases involving trailing slashes that could result in messed up container paths and install paths

Part of addressing #126.
