### PR TITLE
Add option to include all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A configuration file for a sample contains the information about the sample to g
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\
 **installPrefix**: (optional) where the files in **extractPaths** would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc (Note that even on Windows, Unix style `/` directory separators should be used in the path). If not given then the **extractPaths** will be used as the install paths
+**includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those recognized by Surfactant.
 
 #### Create config command
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -23,7 +23,7 @@ $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
 **--input_format**: (optional) specifies the format of the input SBOM if one is being used (default: cytrics) (given as full module name of a surfactant plugin implementing the `read_sbom` hook)\
 **--help**: (optional) show the help message and exit\
-**--inclulde_all_files**: Include all files in the SBOM, rather than just those recognized by Surfactant
+**--include_all_files**: (optional) include all files in the SBOM, rather than just those recognized by Surfactant
 
 
 ## Merging SBOMs

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -22,7 +22,8 @@ $  surfactant generate [OPTIONS] CONFIG_FILE SBOM_OUTFILE [INPUT_SBOM]
 **--recorded_institution**: (optional) the name of the institution collecting the SBOM data (default: LLNL)\
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
 **--input_format**: (optional) specifies the format of the input SBOM if one is being used (default: cytrics) (given as full module name of a surfactant plugin implementing the `read_sbom` hook)\
-**--help**: (optional) show the help message and exit
+**--help**: (optional) show the help message and exit\
+**--inclulde_all_files**: Include all files in the SBOM, rather than just those recognized by Surfactant
 
 
 ## Merging SBOMs

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -44,6 +44,7 @@ A sample configuration file contains the information about the sample to gather 
 **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file (Note that even on Windows, Unix style `/` directory separators should be used in paths)\
 **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in **extractPaths** were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various **extractPaths**\
 **installPrefix**: (optional) where the files in **extractPaths** would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc (Note that even on Windows, Unix style `/` directory separators should be used in the path). If not given then the **extractPaths** will be used as the install paths
+**includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those recognized by Surfactant.
 
 ## Example configuration files
 

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -54,7 +54,7 @@ def get_software_entry(
         filetype=filetype,
         context=context,
         children=sw_children,
-        include_all_files=include_all_files
+        include_all_files=include_all_files,
     )
     # add metadata extracted from the file, and set SBOM fields if metadata has relevant info
     for file_details in extracted_info_results:
@@ -230,7 +230,7 @@ def get_default_from_config(option: str, fallback: Optional[Any] = None) -> Any:
     is_flag=True,
     default=False,
     required=False,
-    help="Include all files in the SBOM, not just those recognized by Surfactant"
+    help="Include all files in the SBOM, not just those recognized by Surfactant",
 )
 def sbom(
     config_file,
@@ -415,7 +415,10 @@ def sbom(
                         else:
                             install_path = None
 
-                        if ftype := pm.hook.identify_file_type(filepath=filepath) or include_all_files:
+                        if (
+                            ftype := pm.hook.identify_file_type(filepath=filepath)
+                            or include_all_files
+                        ):
                             try:
                                 sw_parent, sw_children = get_software_entry(
                                     context,
@@ -427,7 +430,7 @@ def sbom(
                                     container_uuid=parent_uuid,
                                     install_path=install_path,
                                     user_institution_name=recorded_institution,
-                                    include_all_files=include_all_files or entry.includeAllFiles
+                                    include_all_files=include_all_files or entry.includeAllFiles,
                                 )
                             except Exception as e:
                                 raise RuntimeError(f"Unable to process: {filepath}") from e

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -228,7 +228,7 @@ def get_default_from_config(option: str, fallback: Optional[Any] = None) -> Any:
 @click.option(
     "--include_all_files",
     is_flag=True,
-    default=False,
+    default=get_default_from_config("include_all_files", fallback=False),
     required=False,
     help="Include all files in the SBOM, not just those recognized by Surfactant",
 )

--- a/surfactant/config.py
+++ b/surfactant/config.py
@@ -11,3 +11,4 @@ class ContextEntry:
     extractPaths: List[str]
     archive: Optional[str] = None
     installPrefix: Optional[str] = None
+    includeAllFiles: Optional[bool] = None

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -50,7 +50,7 @@ def extract_file_info(
         filetype (str): File type information based on magic bytes.
         context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should still work without adding this parameter.
         children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add additional entries, though if the plugin extracts files to a temporary directory, the context argument should be used to have Surfactant process the files instead.
-        include_all_files (bool): If all files should be included in the SBOM, rather than only those that are identified by Surfactant.
+        include_all_files (bool): If all files should be included in the SBOM, rather than only those with types that are recognized by Surfactant. When a plugin is adding additional context entries to the queue, it should typically default to propagating this value to the new context entries that it creates.
 
     Returns:
         object: An object to be added to the metadata field for the software entry. May be `None` to add no metadata.

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -36,6 +36,7 @@ def extract_file_info(
     filetype: str,
     context: "Queue[ContextEntry]",
     children: List[Software],
+    include_all_files: bool,
 ) -> Optional[list]:
     """Extracts information from the given file to add to the given software entry. Return an
     object to be included as part of the metadata field, and potentially used as part of
@@ -49,6 +50,7 @@ def extract_file_info(
         filetype (str): File type information based on magic bytes.
         context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should still work without adding this parameter.
         children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add additional entries, though if the plugin extracts files to a temporary directory, the context argument should be used to have Surfactant process the files instead.
+        include_all_files (bool): If all files should be included in the SBOM, rather than only those that are identified by Surfactant.
 
     Returns:
         object: An object to be added to the metadata field for the software entry. May be `None` to add no metadata.


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add an option to include all files found in the SBOM, rather than just those identified by Surfactant.  This addresses #238

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
There are two ways to include all files, either passing the `--include_all_files` option to the generate subcommand, or adding and setting to true an `includeAllFiles` option in the input file when specifying extract paths and install paths.