### PR TITLE
added .bat extension

### DIFF
--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -25,6 +25,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
         ".html": "HTML",
         ".htm": "HTML",
         ".php": "PHP",
+        ".bat": "BATCH",
     }
     _interpreters = {
         b"sh": "SHELL",


### PR DESCRIPTION
Adds .bat files to the list of file extensions that are recognized by default by Surfactant. This change was requested during CyTRICS SBOM testing.

If merged this pull request will allow Surfactant to identify .bat files and automatically add information to the SBOM for them.

Just one line added in the id_extensions.py file:

".bat": "BATCH",
