### PR TITLE
Adding basic framework for the CLI, no changes to old cli. 

### DIFF
--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -91,7 +91,7 @@ Our SBOM after the `cli add` command:
 ```
 
 ## surfactant cli save
-The **cli save** command saves the edited sbom to the output file specified. 
+The **cli save** command saves the edited sbom to the output file specified.
 
 ### Example:
 ```bash

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -5,7 +5,7 @@ Some functionality we support includes:
 - Fix up path prefixes, i.e. installPath or containerPath
 - Add relationships
 
-## surfactnat cli load
+## surfactant cli load
 The ***cli load* command loads an sbom file into the cli and serializes it for faster processing when running other cli commands. On Unix-like platforms (including macOS), the XDG directory specification is followed and the serialized sbom will be stored in `${XDG_CONFIG_HOME}/surfactant/config.toml`. If the `XDG_CONFIG_HOME` environment variable is not set, the location defaults
 to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at `%APPDATA%\\surfactant\\sbom_cli`.
 

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -5,6 +5,15 @@ Some functionality we support includes:
 - Fix up path prefixes, i.e. installPath or containerPath
 - Add relationships
 
+## surfactnat cli load
+The ***cli load* command loads an sbom file into the cli and serializes it for faster processing when running other cli commands. On Unix-like platforms (including macOS), the XDG directory specification is followed and the serialized sbom will be stored in `${XDG_CONFIG_HOME}/surfactant/config.toml`. If the `XDG_CONFIG_HOME` environment variable is not set, the location defaults
+to `~/.config`. On Windows, the file is stored in the Roaming AppData folder at `%APPDATA%\\surfactant\\sbom_cli`.
+
+### Example
+```bash
+surfactant cli load sbom.json
+```
+
 ## surfactant cli find
 The **cli find** command allows users to find specific entries within a SBOM. This will allow users to:
 - Verify entries exist within the SBOM
@@ -79,4 +88,12 @@ Our SBOM after the `cli add` command:
 "installPath": ["/bin/helpers/test.exe"],
 "containerPath": ["123/helpers/test.exe"]
 }
+```
+
+## surfactant cli save
+The **cli save** command saves the edited sbom to the output file specified. 
+
+### Example:
+```bash
+surfactant cli save new_sbom.json
 ```

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -11,7 +11,7 @@ import sys
 import click
 from loguru import logger
 
-from surfactant.cmd.cli import add, edit, find
+from surfactant.cmd.cli import handle_cli_add, handle_cli_edit, handle_cli_find, handle_cli_load, handle_cli_save
 from surfactant.cmd.config import config
 from surfactant.cmd.config_tui import config_tui
 from surfactant.cmd.createconfig import create_config
@@ -79,9 +79,11 @@ main.add_command(plugin)
 main.add_command(config_tui)
 
 # CLI Subcommands
-cli.add_command(find)
-cli.add_command(edit)
-cli.add_command(add)
+cli.add_command(handle_cli_find)
+cli.add_command(handle_cli_edit)
+cli.add_command(handle_cli_add)
+cli.add_command(handle_cli_load)
+cli.add_command(handle_cli_save)
 
 # Plugin Subcommands
 plugin.add_command(plugin_list_cmd)

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -11,7 +11,13 @@ import sys
 import click
 from loguru import logger
 
-from surfactant.cmd.cli import handle_cli_add, handle_cli_edit, handle_cli_find, handle_cli_load, handle_cli_save
+from surfactant.cmd.cli import (
+    handle_cli_add,
+    handle_cli_edit,
+    handle_cli_find,
+    handle_cli_load,
+    handle_cli_save,
+)
 from surfactant.cmd.config import config
 from surfactant.cmd.config_tui import config_tui
 from surfactant.cmd.createconfig import create_config

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -5,8 +5,7 @@ from pathlib import Path
 import click
 from loguru import logger
 
-# from surfactant.cmd.cli_commands.cli_load import Load
-from surfactant.cmd.cli_commands import *
+from surfactant.cmd.cli_commands import Load, Save
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
@@ -126,7 +125,6 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
 @click.command("edit")
 def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
-    pass
 
 
 @click.argument("outfile", type=click.File("w"), required=True)

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,19 +1,16 @@
 import hashlib
 import sys
-import os
-import platform
 from pathlib import Path
 
 import click
 from loguru import logger
-import json
 
+# from surfactant.cmd.cli_commands.cli_load import Load
+from surfactant.cmd.cli_commands import *
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
-# from surfactant.cmd.cli_commands.cli_load import Load
-from surfactant.cmd.cli_commands import *
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -143,6 +140,7 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 def handle_cli_save(outfile, output_format):
     "CLI command to save SBOM to a user specified file"
     Save(output_format=output_format).execute(outfile)
+
 
 class cli_add:
     """

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -16,7 +16,9 @@ from surfactant.sbomtypes._software import Software
 @click.option(
     "--input_format",
     is_flag=False,
-    default="surfactant.input_readers.cytrics_reader",
+    default=ConfigManager().get(
+        "core", "input_format", fallback="surfactant.input_readers.cytrics_reader"
+    ),
     help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
 )
 @click.command("load")
@@ -131,7 +133,9 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 @click.option(
     "--output_format",
     is_flag=False,
-    default="surfactant.output.cytrics_writer",
+    default=ConfigManager().get(
+        "core", "output_format", fallback="surfactant.output.cytrics_writer"
+    ),
     help="SBOM output format, options=[cytrics|csv|spdx|cyclonedx]",
 )
 @click.command("save")

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -6,6 +6,7 @@ import click
 from loguru import logger
 
 from surfactant.cmd.cli_commands import Load, Save
+from surfactant.configmanager import ConfigManager
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -67,7 +67,7 @@ def handle_cli_find(sbom, output_format, input_format, **kwargs):
 
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = find().execute(in_sbom, **filtered_kwargs)
+    out_sbom = cli_find().execute(in_sbom, **filtered_kwargs)
     if not out_sbom.software:
         logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
@@ -112,7 +112,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
         in_sbom = input_reader.read_sbom(f)
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = add().execute(in_sbom, **filtered_kwargs)
+    out_sbom = cli_add().execute(in_sbom, **filtered_kwargs)
     # Write to the input file if no output specified
     if output is None:
         with open(Path(sbom), "w") as f:

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+from .cli_base import Cli
 from .cli_load import Load
 from .cli_save import Save
-from .cli_base import Cli
 
 __all__ = ["Load", "Save", "Cli"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .cli_add import Load
-from .cli_find import Save
+from .cli_load import Load
+from .cli_save import Save
 
 __all__ = ["Load", "Save"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -5,5 +5,6 @@
 
 from .cli_load import Load
 from .cli_save import Save
+from .cli_base import Cli
 
-__all__ = ["Load", "Save"]
+__all__ = ["Load", "Save", "Cli"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -6,7 +6,4 @@
 from .cli_add import Load
 from .cli_find import Save
 
-__all__ = [
-    "Load",
-    "Save"
-]
+__all__ = ["Load", "Save"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+from .cli_add import Load
+from .cli_find import Save
+
+__all__ = [
+    "Load",
+    "Save"
+]

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -15,12 +15,12 @@ class Cli:
     A base class that implements the surfactant cli basic functionality
 
     Attributes:
-    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
-    subset                  An internal record of the subset of sbom entries from the last cli find call.
-    sbom_filename:          A string value of the filename where the loaded sbom is stored.
-    subset_filename:        A string value of the filename where the current subset result from the "cli find" command is stored.
-    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
-    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+        sbom: An internal record of sbom entries the class adds to as it finds more matches.
+        subset: An internal record of the subset of sbom entries from the last cli find call.
+        sbom_filename: A string value of the filename where the loaded sbom is stored.
+        subset_filename: A string value of the filename where the current subset result from the "cli find" command is stored.
+        match_functions: A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+        camel_case_conversions: A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
 
     """
 

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,9 +1,6 @@
 import dataclasses
-import os
 import pickle
-import platform
 from dataclasses import Field
-from pathlib import Path
 
 from loguru import logger
 
@@ -35,28 +32,18 @@ class Cli:
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"
         # Create data directory
-        self.data_dir = self._get_cli_sbom_dir()
+        self.data_dir = self.ConfigManager().get_data_dir_path()
         self.data_dir.mkdir(parents=True, exist_ok=True)
-
-    def _get_cli_sbom_dir(self) -> Path:
-        """Determines the path to the loaded serialized sbom file.
-
-        Returns:
-            Path: The directory path to where the serialized sboms are stored.
-        """
-        if platform.system() == "Windows":
-            data_dir = Path(os.getenv("APPDATA", os.path.expanduser("~\\AppData\\Roaming")))
-        else:
-            data_dir = Path(os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share")))
-        data_dir = data_dir / "surfactant"
-        return data_dir
 
     @staticmethod
     def serialize(sbom: SBOM) -> str:
         """Serializes a given sbom.
 
+        Args:
+            bom (SBOM): Aninstance of an SBOM to serialize
+
         Returns:
-            str: A string representation of the serialized SBOM.
+            bytes: A binary representation of the serialized SBOM.
         """
         # NOTE: python pickle cannot pickle MappingProxyType, which is inherently included in the Field type.
         # Pickling is much faster than converting to json or msgpack (see MR for timings: https://github.com/LLNL/Surfactant/pull/261
@@ -75,8 +62,11 @@ class Cli:
     def deserialize(data) -> SBOM:
         """Deserializes the given data and saves them in the SBOM class instance
 
+        Args:
+            data (bytes): The data to deserialize into an SBOM type
+
         Returns:
-            SBOM: A SBOM instance.
+            SBOM: An SBOM instance.
         """
         try:
             sbom = pickle.loads(data)

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -58,6 +58,11 @@ class Cli:
         Returns:
             str: A string representation of the serialized SBOM.
         """
+        # NOTE: python pickle cannot pickle MappingProxyType, which is inherently included in the Field type. 
+        # Pickling is much faster than converting to json or msgpack (see MR for timings: https://github.com/LLNL/Surfactant/pull/261
+        # To workaround the issue we replace the metadata attribute of the Field type (which is default mappingproxytype) with an empty dict
+        # Upon deserialization, we recreate the class with dataclasses.replace() to ensure the unpickled class instance is intact. Without this, 
+        # the class function to_json() and to_dict() does not work as the Field type is no longer recongized.
         if isinstance(sbom, SBOM):
             for _, v in sbom.__dataclass_fields__.items():
                 if isinstance(v, Field):

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -58,10 +58,10 @@ class Cli:
         Returns:
             str: A string representation of the serialized SBOM.
         """
-        # NOTE: python pickle cannot pickle MappingProxyType, which is inherently included in the Field type. 
+        # NOTE: python pickle cannot pickle MappingProxyType, which is inherently included in the Field type.
         # Pickling is much faster than converting to json or msgpack (see MR for timings: https://github.com/LLNL/Surfactant/pull/261
         # To workaround the issue we replace the metadata attribute of the Field type (which is default mappingproxytype) with an empty dict
-        # Upon deserialization, we recreate the class with dataclasses.replace() to ensure the unpickled class instance is intact. Without this, 
+        # Upon deserialization, we recreate the class with dataclasses.replace() to ensure the unpickled class instance is intact. Without this,
         # the class function to_json() and to_dict() does not work as the Field type is no longer recongized.
         if isinstance(sbom, SBOM):
             for _, v in sbom.__dataclass_fields__.items():

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -41,7 +41,7 @@ class Cli:
         """Serializes a given sbom.
 
         Args:
-            bom (SBOM): Aninstance of an SBOM to serialize
+            bom (SBOM): An instance of an SBOM to serialize
 
         Returns:
             bytes: A binary representation of the serialized SBOM.

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -4,8 +4,8 @@ from dataclasses import Field
 
 from loguru import logger
 
-from surfactant.sbomtypes._sbom import SBOM
 from surfactant.configmanager import ConfigManager
+from surfactant.sbomtypes._sbom import SBOM
 
 
 class Cli:
@@ -33,7 +33,7 @@ class Cli:
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"
         # Create data directory
-        self.data_dir = self.ConfigManager().get_data_dir_path()
+        self.data_dir = ConfigManager().get_data_dir_path()
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
     @staticmethod

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 from loguru import logger
 
-from loguru import logger
-
 from surfactant.sbomtypes._sbom import SBOM
 
 

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,10 +1,10 @@
 import os
-import platform
-from json.decoder import JSONDecodeError
-from pathlib import Path
 import pickle
-from loguru import logger
+import platform
+from pathlib import Path
 from types import MappingProxyType
+
+from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM
 

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import json
+import os
+import platform
+from loguru import logger
+
+from surfactant.sbomtypes._sbom import SBOM
+
+
+class Cli:
+    """
+    A base class that implements the surfactant cli basic functionality
+
+    Attributes:
+    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
+    subset                  An internal record of the subset of sbom entries from the last cli find call.
+    """
+    sbom: SBOM = None
+    subset: SBOM = None
+    sbom_filename: str
+    subset_filename: str
+    match_functions: dict
+    camel_case_conversions: dict
+    
+    def __init__(self):
+        self.sbom_filename = "sbom_cli"
+        self.subset_filename = "subset_cli"
+        # Create data directory
+        self.data_dir = self._get_cli_sbom_dir()
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_cli_sbom_dir(self) -> Path:
+        """Determines the path to the loaded serialized sbom file.
+
+        Returns:
+            Path: The directory path to where the serialized sboms are stored.
+        """
+        if platform.system() == "Windows":
+            data_dir = Path(os.getenv("APPDATA", os.path.expanduser("~\\AppData\\Roaming")))
+        else:
+            data_dir = Path(os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share")))
+        data_dir = data_dir / "surfactant"
+        return data_dir 
+
+
+    def serialize(self, sbom: SBOM) -> bool:
+        """Serializes the internal sbom and subset sbom (if it exists) and saves them to the filesystem
+        """
+        try:    
+            return sbom.to_json(indent=2).encode("utf-8")
+        except Exception as e:
+            logger.error(f"Could not serialize sbom - {e}")
+
+    def deserialize(self, data) -> SBOM:
+        """Deserializes the sbom and subset sbom (if it exists) and saves them in the class instance
+        """ 
+        try:   
+            return SBOM.from_json(data.decode("utf-8"))
+        except Exception as e:
+            logger.error(f"Could not deserialize sbom from given data - {e}")
+

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,7 +1,7 @@
-from pathlib import Path
-import json
 import os
 import platform
+from pathlib import Path
+
 from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM
@@ -17,13 +17,14 @@ class Cli:
     sbom                    An internal record of sbom entries the class adds to as it finds more matches.
     subset                  An internal record of the subset of sbom entries from the last cli find call.
     """
+
     sbom: SBOM = None
     subset: SBOM = None
     sbom_filename: str
     subset_filename: str
     match_functions: dict
     camel_case_conversions: dict
-    
+
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"
@@ -42,22 +43,18 @@ class Cli:
         else:
             data_dir = Path(os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share")))
         data_dir = data_dir / "surfactant"
-        return data_dir 
-
+        return data_dir
 
     def serialize(self, sbom: SBOM) -> bool:
-        """Serializes the internal sbom and subset sbom (if it exists) and saves them to the filesystem
-        """
-        try:    
+        """Serializes the internal sbom and subset sbom (if it exists) and saves them to the filesystem"""
+        try:
             return sbom.to_json(indent=2).encode("utf-8")
         except Exception as e:
             logger.error(f"Could not serialize sbom - {e}")
 
     def deserialize(self, data) -> SBOM:
-        """Deserializes the sbom and subset sbom (if it exists) and saves them in the class instance
-        """ 
-        try:   
+        """Deserializes the sbom and subset sbom (if it exists) and saves them in the class instance"""
+        try:
             return SBOM.from_json(data.decode("utf-8"))
         except Exception as e:
             logger.error(f"Could not deserialize sbom from given data - {e}")
-

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -51,7 +51,8 @@ class Cli:
         data_dir = data_dir / "surfactant"
         return data_dir
 
-    def serialize(self, sbom: SBOM) -> str:
+    @staticmethod
+    def serialize(sbom: SBOM) -> str:
         """Serializes a given sbom.
 
         Returns:
@@ -65,7 +66,8 @@ class Cli:
         logger.error(f"Could not serialize sbom - {type(sbom)} is not of type SBOM")
         return None
 
-    def deserialize(self, data) -> SBOM:
+    @staticmethod
+    def deserialize(data) -> SBOM:
         """Deserializes the given data and saves them in the SBOM class instance
 
         Returns:

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -5,6 +5,7 @@ from dataclasses import Field
 from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM
+from surfactant.configmanager import ConfigManager
 
 
 class Cli:

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,9 +1,10 @@
+import dataclasses
 import os
 import pickle
 import platform
 from dataclasses import Field
 from pathlib import Path
-import dataclasses
+
 from loguru import logger
 
 from loguru import logger
@@ -74,7 +75,9 @@ class Cli:
         """
         try:
             sbom = pickle.loads(data)
-            return dataclasses.replace(sbom) # Create a copy to repopulate anything that got messed up in serialization
+            return dataclasses.replace(
+                sbom
+            )  # Create a copy to repopulate anything that got messed up in serialization
         except pickle.UnpicklingError as e:
             logger.error(f"Could not deserialize sbom from given data - {e}")
             return None

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -26,6 +26,6 @@ class Load(Cli):
         input_reader = find_io_plugin(pm, self.input_format, "read_sbom")
         self.sbom = input_reader.read_sbom(input_file)
 
-        serialized_sbom = self.serialize(self.sbom)
+        serialized_sbom = Cli.serialize(self.sbom)
         with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
             f.write(serialized_sbom)

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -1,14 +1,15 @@
-from loguru import logger
 from pathlib import Path
 
-from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+
 
 class Load(Cli):
     """
     A class that implements the surfactant cli load functionality
 
     """
+
     def __init__(self, *args, input_format, **kwargs):
         """Executes the load class constructor
 

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -1,0 +1,30 @@
+from loguru import logger
+from pathlib import Path
+
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+from surfactant.cmd.cli_commands.cli_base import Cli
+
+class Load(Cli):
+    """
+    A class that implements the surfactant cli load functionality
+
+    """
+    def __init__(self, *args, input_format, **kwargs):
+        """Executes the load class constructor
+
+        param: input_format   The format of the sbom being loaded
+        """
+        self.input_format = input_format
+        super().__init__(*args, **kwargs)
+
+    def execute(self, input_file):
+        """Executes the main functionality of the load class
+        param: input_file   The sbom load into the cli
+        """
+        pm = get_plugin_manager()
+        input_reader = find_io_plugin(pm, self.input_format, "read_sbom")
+        self.sbom = input_reader.read_sbom(input_file)
+
+        serialized_sbom = self.serialize(self.sbom)
+        with open(Path(self.data_dir, self.sbom_filename), "wb+") as f:
+            f.write(serialized_sbom)

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -11,6 +11,7 @@ class Load(Cli):
     Attributes:
         input_format (str): The format for input sboms
     """
+
     def __init__(self, *args, input_format, **kwargs):
         """Executes the load class constructor
 

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -27,5 +27,5 @@ class Load(Cli):
         self.sbom = input_reader.read_sbom(input_file)
 
         serialized_sbom = self.serialize(self.sbom)
-        with open(Path(self.data_dir, self.sbom_filename), "wb+") as f:
+        with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
             f.write(serialized_sbom)

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -8,19 +8,23 @@ class Load(Cli):
     """
     A class that implements the surfactant cli load functionality
 
+    Attributes:
+        input_format (str): The format for input sboms
     """
-
     def __init__(self, *args, input_format, **kwargs):
         """Executes the load class constructor
 
-        param: input_format   The format of the sbom being loaded
+        Args:
+            input_format (str): The format of the sbom being loaded
         """
         self.input_format = input_format
         super().__init__(*args, **kwargs)
 
     def execute(self, input_file):
         """Executes the main functionality of the load class
-        param: input_file   The sbom load into the cli
+
+        Args:
+            input_file: The sbom load into the cli
         """
         pm = get_plugin_manager()
         input_reader = find_io_plugin(pm, self.input_format, "read_sbom")

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from surfactant.sbomtypes._sbom import SBOM
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 
@@ -24,10 +25,8 @@ class Save(Cli):
         """
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
-        input_reader = find_io_plugin(pm, "surfactant.input_readers.cytrics_reader", "read_sbom")
 
         with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
             data = f.read()
-            self.sbom = self.deserialize(data)
-
+        self.sbom = self.deserialize(data)
         output_writer.write_sbom(self.sbom, output_file)

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from surfactant.sbomtypes._sbom import SBOM
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -27,5 +27,5 @@ class Save(Cli):
 
         with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
             data = f.read()
-        self.sbom = self.deserialize(data)
+        self.sbom = Cli.deserialize(data)
         output_writer.write_sbom(self.sbom, output_file)

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -8,19 +8,24 @@ class Save(Cli):
     """
     A class that implements the surfactant cli save functionality
 
+    Attributes:
+        output_format (str): The format of the sbom to be outputted
     """
 
     def __init__(self, *args, output_format, **kwargs):
         """Executes the load class constructor
 
-        param: input_format   The format of the sbom being loaded
+        Args:
+            output_format (str): The format of the sbom to be outputted
         """
         self.output_format = output_format
         super().__init__(*args, **kwargs)
 
     def execute(self, output_file):
         """Executes the main functionality of the load class
-        param: input_file   The sbom load into the cli
+
+        Args:
+            output_file:  The file to save the sbom to
         """
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,14 +1,15 @@
-from loguru import logger
 from pathlib import Path
 
-from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+
 
 class Save(Cli):
     """
     A class that implements the surfactant cli save functionality
 
     """
+
     def __init__(self, *args, output_format, **kwargs):
         """Executes the load class constructor
 
@@ -24,11 +25,9 @@ class Save(Cli):
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
         input_reader = find_io_plugin(pm, "surfactant.input_readers.cytrics_reader", "read_sbom")
-   
+
         with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
             data = f.read()
             self.sbom = self.deserialize(data)
 
         output_writer.write_sbom(self.sbom, output_file)
-
-

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,0 +1,34 @@
+from loguru import logger
+from pathlib import Path
+
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+from surfactant.cmd.cli_commands.cli_base import Cli
+
+class Save(Cli):
+    """
+    A class that implements the surfactant cli save functionality
+
+    """
+    def __init__(self, *args, output_format, **kwargs):
+        """Executes the load class constructor
+
+        param: input_format   The format of the sbom being loaded
+        """
+        self.output_format = output_format
+        super().__init__(*args, **kwargs)
+
+    def execute(self, output_file):
+        """Executes the main functionality of the load class
+        param: input_file   The sbom load into the cli
+        """
+        pm = get_plugin_manager()
+        output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
+        input_reader = find_io_plugin(pm, "surfactant.input_readers.cytrics_reader", "read_sbom")
+   
+        with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
+            data = f.read()
+            self.sbom = self.deserialize(data)
+
+        output_writer.write_sbom(self.sbom, output_file)
+
+

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -8,7 +8,7 @@ import pathlib
 import pytest
 
 from surfactant.cmd.cli import cli_add, cli_find
-from surfactant.cmd.cli_commands import Load, Save, Cli
+from surfactant.cmd.cli_commands import Cli
 from surfactant.sbomtypes import SBOM, Relationship
 
 
@@ -163,4 +163,3 @@ def test_cli_base_serialization(test_sbom):
     deserialized = c.deserialize(serialized)
     assert test_sbom == deserialized
     assert test_sbom.to_dict() == deserialized.to_dict()
-    

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -158,8 +158,7 @@ def test_add_installpath(test_sbom):
 
 
 def test_cli_base_serialization(test_sbom):
-    c = Cli()
-    serialized = c.serialize(test_sbom)
-    deserialized = c.deserialize(serialized)
+    serialized = Cli.serialize(test_sbom)
+    deserialized = Cli.deserialize(serialized)
     assert test_sbom == deserialized
     assert test_sbom.to_dict() == deserialized.to_dict()

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -8,6 +8,7 @@ import pathlib
 import pytest
 
 from surfactant.cmd.cli import cli_add, cli_find
+from surfactant.cmd.cli_commands import Load, Save, Cli
 from surfactant.sbomtypes import SBOM, Relationship
 
 
@@ -154,3 +155,12 @@ def test_add_installpath(test_sbom):
     for sw in out_bom.software:
         if containerPathPrefix in sw.containerPath:
             assert installPathPrefix in sw.installPath
+
+
+def test_cli_base_serialization(test_sbom):
+    c = Cli()
+    serialized = c.serialize(test_sbom)
+    deserialized = c.deserialize(serialized)
+    assert test_sbom == deserialized
+    assert test_sbom.to_dict() == deserialized.to_dict()
+    

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -19,6 +19,26 @@ def fixture_test_sbom():
         return sbom
 
 
+def _compare_sboms(one: SBOM, two: SBOM) -> bool:
+    # Sort software list
+    one.software = sorted(one.software, key=lambda x: x.UUID)
+    two.software = sorted(two.software, key=lambda x: x.UUID)
+
+    # Sort hardware list
+    one.hardware = sorted(one.hardware, key=lambda x: x.UUID)
+    two.hardware = sorted(two.hardware, key=lambda x: x.UUID)
+
+    # Sort system list
+    one.systems = sorted(one.systems, key=lambda x: x.UUID)
+    two.systems = sorted(two.systems, key=lambda x: x.UUID)
+
+    # Sort relationship list
+    one.relationships = sorted(one.relationships, key=lambda x: x.yUUID)
+    two.relationships = sorted(two.relationships, key=lambda x: x.yUUID)
+
+    return one.to_dict() == two.to_dict()
+
+
 bad_sbom = SBOM(
     {
         "software": [
@@ -161,4 +181,4 @@ def test_cli_base_serialization(test_sbom):
     serialized = Cli.serialize(test_sbom)
     deserialized = Cli.deserialize(serialized)
     assert test_sbom == deserialized
-    assert test_sbom.to_dict() == deserialized.to_dict()
+    assert _compare_sboms(test_sbom, deserialized)


### PR DESCRIPTION
### Summary
This MR adds the basic setup for the new non-interactive surfactant cli. 

If merged this pull request will
- add a `surfactant cli load` command
- add a `surfactant cli save` command
- add a new subfolder surfactant/cmd/cli_commands that contains the cli classes related to each subcommand (base, save, load)
- Initial structure to provide serialization for SBOMs (right now it just saves it as json (pickling does not work right now))

### Proposed changes
The changes here will migrate the existing cli interface to the new structure. Proposed workflow is below:
```
surfactant cli load sbom.json # Loads the sbom into surfactant, surfactantn saves it in ~/.surfactant in a serialized form
surfactant cli find --containerPath=^123* # Loads from serialized form and finds subset that matches args
surfactant cli add --installPath 123/ /bin/ # Adds new install path based on containerpath
surfactant cli merge # merges changes to the subset from find back into the main sbom
surfactant cli find --uuid 123 # Find one entry to edit based on uuid
surfactant cli edit --components="IsAGRAF" # Editing an array by picking the element, this one edits a specific component in this entry
Current Value: {"name": "IsAGRAF", "Vendor": "Rockwell Collins Automation"}
New Value: {"name": "IsAGRAF", "Vendor": ["Rockwell Collins Automation"], "version": "1.2.3"} 
surfactant cli edit --name # Edit a string value
Current Value: oldname.out
New Value: 1.2.3.CPO.out
surfactant cli merge # Merge changes back into the rest of the SBOM
surfactant cli save new_sbom.json # save edited sbom to a new file
```