### PR TITLE
Add dependency groups for dev, test, and docs tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ Documentation = "https://surfactant.readthedocs.io/en/latest/"
 "Issue Tracker" = "https://github.com/LLNL/Surfactant/issues"
 "Source Code" = "https://github.com/LLNL/Surfactant"
 
+[dependency-groups]
+test = ["pytest"]
+dev = ["build", "pre-commit"]
+docs = ["sphinx", "myst-parser"]
+
 [tool.setuptools.packages.find]
 include = ["surfactant", "surfactant.*"]
 


### PR DESCRIPTION
Python added dependency-groups ([PEP 735](https://peps.python.org/pep-0735/)) as an addition to pyproject.toml files. It is basically like optional dependencies, except they are never included in a built package, and installing them does not imply also installing a copy of the package (e.g. `pip install .[dev]` would install Surfactant along with the dev optional dependencies; installing the dev dependency group would just install the tools).

pip is in the process of adding support for installing from dependency groups; currently the easiest way to work with dependency groups is to install the [dependency-groups](https://pypi.org/project/dependency-groups/) package, and then run `pip-install-dependency-groups [dependency_group_name]`.