### PR TITLE
Remove ref name entry from .git_archival.txt

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Apparently this isn't stable when downloading the
source archive generated by GitHub. See this doc page and issue for details...
https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives