### PR TITLE
Add zlib file identification

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -192,6 +192,14 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 int.from_bytes(magic_bytes[0:4], byteorder="big", signed=False) & 0xFF0F80FF
             ) == 0xF00D0000:
                 return "OMF_LIB"
+            # zlib:
+            # https://www.rfc-editor.org/rfc/rfc1950
+            cmf = magic_bytes[0]
+            flg = magic_bytes[1]
+            cm = cmf & 0x0F
+            if cm == 8:
+                if (cmf * 256 + flg) % 31 == 0:
+                    return "ZLIB"
             return None
     except FileNotFoundError:
         return None

--- a/tests/file_types/test_file_magic.py
+++ b/tests/file_types/test_file_magic.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: MIT
 import os
 import pathlib
-import zlib
 import sys
+import zlib
+
 import pytest
 
 from surfactant.filetypeid.id_magic import identify_file_type
@@ -41,13 +42,16 @@ def test_magic_id():
 def test_zlib_basic(tmp_path):
     for compress_level in range(10):
         write_to = tmp_path / f"basic_{compress_level}.zlib"
-        write_to.write_bytes(zlib.compress(b'hello', level=compress_level))
-        assert identify_file_type(write_to) == 'ZLIB'
+        write_to.write_bytes(zlib.compress(b"hello", level=compress_level))
+        assert identify_file_type(write_to) == "ZLIB"
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="zlib.compress wbits only available from Python 3.11+")
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="zlib.compress wbits only available from Python 3.11+"
+)
 def test_zlib_window(tmp_path):
     for compress_level in range(10):
         for window_size in range(9, 16):
             write_to = tmp_path / f"window_{compress_level}_{window_size}.zlib"
-            write_to.write_bytes(zlib.compress(b'hello', level=compress_level, wbits=window_size))
-            assert identify_file_type(write_to) == 'ZLIB'
+            write_to.write_bytes(zlib.compress(b"hello", level=compress_level, wbits=window_size))
+            assert identify_file_type(write_to) == "ZLIB"

--- a/tests/file_types/test_file_magic.py
+++ b/tests/file_types/test_file_magic.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: MIT
 import os
 import pathlib
+import zlib
+import sys
+import pytest
 
 from surfactant.filetypeid.id_magic import identify_file_type
 
@@ -33,3 +36,18 @@ def test_magic_id():
     data_dir = os.path.join(base_path, "..", "data")
     for file_name, file_type in _file_to_file_type.items():
         assert identify_file_type(os.path.join(data_dir, file_name)) == file_type
+
+
+def test_zlib_basic(tmp_path):
+    for compress_level in range(10):
+        write_to = tmp_path / f"basic_{compress_level}.zlib"
+        write_to.write_bytes(zlib.compress(b'hello', level=compress_level))
+        assert identify_file_type(write_to) == 'ZLIB'
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="zlib.compress wbits only available from Python 3.11+")
+def test_zlib_window(tmp_path):
+    for compress_level in range(10):
+        for window_size in range(9, 16):
+            write_to = tmp_path / f"window_{compress_level}_{window_size}.zlib"
+            write_to.write_bytes(zlib.compress(b'hello', level=compress_level, wbits=window_size))
+            assert identify_file_type(write_to) == 'ZLIB'


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add zlib identification logic.  It does _not_ check checksums at present, however.

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
This is a pure addition to add zlib identification logic.  It also changes the tested Python versions from 3.8, 3.9, and 3.10 to 3.8, 3.10, and 3.13, as version 3.11 or higher is required for more robust unit testing of the logic.