### PR TITLE
Recognize Perl Scripts

### DIFF
--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -27,7 +27,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
         ".php": "PHP",
         ".bat": "BATCH",
         ".pl": "PERL_OR_PROLOG",
-        ".pm": "PERL_MODULE"
+        ".pm": "PERL_MODULE",
     }
     _interpreters = {
         b"sh": "SHELL",

--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -26,6 +26,8 @@ def identify_file_type(filepath: str) -> Optional[str]:
         ".htm": "HTML",
         ".php": "PHP",
         ".bat": "BATCH",
+        ".pl": "PERL",
+        ".pm": "PERL_MODULE"
     }
     _interpreters = {
         b"sh": "SHELL",
@@ -34,6 +36,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
         b"php": "PHP",
         b"python": "PYTHON",
         b"python3": "PYTHON",
+        b"perl": "PERL",
     }
     try:
         with open(filepath, "rb") as f:

--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -26,7 +26,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
         ".htm": "HTML",
         ".php": "PHP",
         ".bat": "BATCH",
-        ".pl": "PERL",
+        ".pl": "PERL_OR_PROLOG",
         ".pm": "PERL_MODULE"
     }
     _interpreters = {


### PR DESCRIPTION
I added .pl and .pm file extensions to be recognized and added Perl as a recognizable interpreter

If merged this pull request will allow Surfactant to recognize files with the .pl and .pm extension and recognize Perl as an interpreter. I added .pl, .pm, to the filetype_extensions list in surfactant/filetypeid/id_extensions.py and Perl to the interpreters list.

This PR addresses issue #233 and adds the most rudimentary fix to the issue. A couple thoughts on this issue:
- I'm not sure how Perl is most commonly  distributed in the wild, but I am aware of PerlApp that is used to compile a Perl script into a standalone binary with the script embedded and a copy of the Perl interpreter. Unfortunately, my change wouldn't catch that, but my intuition is that Perl is generally just run as a script with the Perl interpreter on a .pl file which my change would catch.
- I think there are some other ways that we could identify a Perl script such as $, @, % for variable names, looking for pragmas like warnings or strict, or checking for unique built in functions like chomp, but the presence of all of those would only raise the statistical likelihood of it being a Perl file and aren't necessarily definitive.

I think this is a solid fix now and maybe if we run into problems identifying Perl files in the future we can explore this again!