### PR TITLE
feat: Add configuration option to enable/disable Docker Scout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^(.gitignore|generate_sbom.py|extract_file_info.py|pe_info.py)
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.2
     hooks:
       # Run the linter
       - id: ruff

--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ Getting the currently set value for the option would then be done with:
 surfactant config core.recorded_institution
 ```
 
+### Configuration Options
+
+- **docker.enable_docker_scout**: Controls whether Docker Scout is enabled. Default is `true`. To disable Docker Scout, run:
+  
+```bash
+surfactant config docker.enable_docker_scout false
+```
+
 ### Manual Editing
 
 If desired, the settings config file can also be manually edited. The location of the file will depend on your platform.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ surfactant config core.recorded_institution
 ### Configuration Options
 
 - **docker.enable_docker_scout**: Controls whether Docker Scout is enabled. Default is `true`. To disable Docker Scout, run:
-  
+
 ```bash
 surfactant config docker.enable_docker_scout false
 ```

--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ Getting the currently set value for the option would then be done with:
 surfactant config core.recorded_institution
 ```
 
-### Configuration Options
-
-- **docker.enable_docker_scout**: Controls whether Docker Scout is enabled. Default is `true`. To disable Docker Scout, run:
+Another example of a setting you might want to change is `docker.enable_docker_scout`, which controls whether Docker Scout is enabled. To disable Docker Scout (which also suppresses the warning message about installing Docker Scout), set this option to `false`:
 
 ```bash
 surfactant config docker.enable_docker_scout false

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,6 +11,11 @@ See the [this page](configuration_files.md#settings-configuration-file) for deta
 - recorded_institution
     - Name of user's institution.
 
+## docker
+
+- enable_docker_scout
+    - Controls whether Docker Scout is enabled. Default is `true`. Docker Scout must be installed on the same system as Surfactant to work. To disable Docker Scout and/or suppress the message about installing Docker Scout, run `surfactant config docker.enable_docker_scout false`.
+
 ## macho
 
 > Note: Mach-O file support requires installing Surfactant with the `macho` optional dependencies (e.g. `pipx install surfactant[macho]`).

--- a/surfactant/infoextractors/docker_image.py
+++ b/surfactant/infoextractors/docker_image.py
@@ -12,15 +12,26 @@ from loguru import logger
 
 import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
+from surfactant.configmanager import ConfigManager
 
 
 class DockerScoutManager:
     def __init__(self) -> None:
-        self.disable_docker_scout = True
+        # Initialize ConfigManager
+        config_manager = ConfigManager()
+        
+        # Retrieve the configuration option
+        enable_docker_scout = config_manager.get("docker", "enable_docker_scout", True)
+        
+        # Set disable_docker_scout based on the configuration
+        self.disable_docker_scout = not enable_docker_scout
         self.docker_scout_installed = False
 
     def check_docker_scout_installed(self) -> None:
         """Check if Docker Scout is installed and update the state accordingly."""
+        if self.disable_docker_scout:
+            return  # Do nothing if Docker Scout is disabled by config
+        
         try:
             result = subprocess.run(["docker", "scout"], capture_output=True, check=False)
             self.docker_scout_installed = result.returncode == 0
@@ -29,10 +40,16 @@ class DockerScoutManager:
 
         self.disable_docker_scout = not self.docker_scout_installed
         if not self.docker_scout_installed:
-            logger.warning("Install Docker Scout to scan containers for additional information")
+            logger.warning(
+                "Install Docker Scout to scan containers for additional information. "
+                "You can also disable this check by running 'surfactant config docker.enable_docker_scout false'."
+            )
 
     def run_docker_scout(self, filename: str) -> object:
         """Run Docker Scout on the given file and return the results."""
+        if self.disable_docker_scout:
+            return {}  # Do nothing if Docker Scout is disabled by config
+
         try:
             result = subprocess.run(
                 ["docker", "scout", "sbom", "--format", "spdx", f"fs://{filename}"],
@@ -80,5 +97,5 @@ def extract_docker_info(filetype: str, filename: str) -> object:
 
 @surfactant.plugin.hookimpl
 def init_hook(command_name: Optional[str] = None) -> None:
-    if command_name != "update-db":
+    if command_name != "update-db" and not dsManager.disable_docker_scout:
         dsManager.check_docker_scout_installed()


### PR DESCRIPTION
- Integrated ConfigManager to retrieve 'enable_docker_scout' setting.
- Modified DockerScoutManager to respect the configuration option, allowing users to enable or disable Docker Scout functionality.
- Updated init_hook to conditionally check Docker Scout installation based on configuration.
- Added logic to short-circuit Docker Scout operations if disabled via configuration.