### PR TITLE
Cyt 689 migrate cli

### DIFF
--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -18,6 +18,7 @@ from surfactant.cmd.cli import (
     handle_cli_load,
     handle_cli_unload,
     handle_cli_save,
+    handle_cli_merge,
 )
 from surfactant.cmd.config import config
 from surfactant.cmd.config_tui import config_tui
@@ -92,6 +93,7 @@ cli.add_command(handle_cli_add)
 cli.add_command(handle_cli_load)
 cli.add_command(handle_cli_unload)
 cli.add_command(handle_cli_save)
+cli.add_command(handle_cli_merge)
 
 # Plugin Subcommands
 plugin.add_command(plugin_list_cmd)

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -16,6 +16,7 @@ from surfactant.cmd.cli import (
     handle_cli_edit,
     handle_cli_find,
     handle_cli_load,
+    handle_cli_unload,
     handle_cli_save,
 )
 from surfactant.cmd.config import config
@@ -89,6 +90,7 @@ cli.add_command(handle_cli_find)
 cli.add_command(handle_cli_edit)
 cli.add_command(handle_cli_add)
 cli.add_command(handle_cli_load)
+cli.add_command(handle_cli_unload)
 cli.add_command(handle_cli_save)
 
 # Plugin Subcommands

--- a/surfactant/__main__.py
+++ b/surfactant/__main__.py
@@ -16,9 +16,9 @@ from surfactant.cmd.cli import (
     handle_cli_edit,
     handle_cli_find,
     handle_cli_load,
-    handle_cli_unload,
-    handle_cli_save,
     handle_cli_merge,
+    handle_cli_save,
+    handle_cli_unload,
 )
 from surfactant.cmd.config import config
 from surfactant.cmd.config_tui import config_tui

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -17,7 +17,9 @@ from surfactant.sbomtypes._software import Software
 @click.option(
     "--input_format",
     is_flag=False,
-    default="surfactant.input_readers.cytrics_reader",
+    default=ConfigManager().get(
+        "core", "input_format", fallback="surfactant.input_readers.cytrics_reader"
+    ),
     help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
 )
 @click.command("load")

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -84,7 +84,7 @@ def handle_cli_find(sbom, output_format, input_format, **kwargs):
 
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = find().execute(in_sbom, **filtered_kwargs)
+    out_sbom = cli_find().execute(in_sbom, **filtered_kwargs)
     if not out_sbom.software:
         logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
@@ -129,7 +129,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
         in_sbom = input_reader.read_sbom(f)
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = add().execute(in_sbom, **filtered_kwargs)
+    out_sbom = cli_add().execute(in_sbom, **filtered_kwargs)
     # Write to the input file if no output specified
     if output is None:
         with open(Path(sbom), "w") as f:

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -92,7 +92,6 @@ def handle_cli_add(**kwargs):
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
     add = Add()
     success = add.execute(**filtered_kwargs)
-    # Write result to stdout in the cytrics format
     if success:
         logger.info("Changes successfully added.")
 
@@ -103,6 +102,12 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
     pass
 
+@click.command("merge")
+def handle_cli_merge():
+    "CLI command to merge subset sbom into main sbom"
+    success = Merge().execute()
+    if success:
+        logger.info("Merge successful.")
 
 @click.argument("outfile", type=click.File("w"), required=True)
 @click.option(

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,9 +1,12 @@
 import hashlib
 import sys
+import os
+import platform
 from pathlib import Path
 
 import click
 from loguru import logger
+import json
 
 from surfactant.cmd.cli_commands import Load, Save
 from surfactant.configmanager import ConfigManager
@@ -11,6 +14,21 @@ from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
+# from surfactant.cmd.cli_commands.cli_load import Load
+from surfactant.cmd.cli_commands import *
+
+
+@click.argument("sbom", type=click.File("r"), required=True)
+@click.option(
+    "--input_format",
+    is_flag=False,
+    default="surfactant.input_readers.cytrics_reader",
+    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
+)
+@click.command("load")
+def handle_cli_load(sbom, input_format):
+    "CLI command to load supplied SBOM into cli"
+    Load(input_format=input_format).execute(sbom)
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -66,7 +84,7 @@ def handle_cli_find(sbom, output_format, input_format, **kwargs):
 
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = cli_find().execute(in_sbom, **filtered_kwargs)
+    out_sbom = find().execute(in_sbom, **filtered_kwargs)
     if not out_sbom.software:
         logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
@@ -111,7 +129,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
         in_sbom = input_reader.read_sbom(f)
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = cli_add().execute(in_sbom, **filtered_kwargs)
+    out_sbom = add().execute(in_sbom, **filtered_kwargs)
     # Write to the input file if no output specified
     if output is None:
         with open(Path(sbom), "w") as f:
@@ -128,6 +146,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
 @click.command("edit")
 def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
+    pass
 
 
 @click.argument("outfile", type=click.File("w"), required=True)
@@ -143,7 +162,6 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 def handle_cli_save(outfile, output_format):
     "CLI command to save SBOM to a user specified file"
     Save(output_format=output_format).execute(outfile)
-
 
 class cli_add:
     """

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -141,7 +141,6 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
 @click.command("edit")
 def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
-    pass
 
 
 @click.argument("outfile", type=click.File("w"), required=True)

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,9 +1,12 @@
 import hashlib
 import sys
+import os
+import platform
 from pathlib import Path
 
 import click
 from loguru import logger
+import json
 
 from surfactant.cmd.cli_commands import Load, Save
 from surfactant.configmanager import ConfigManager
@@ -11,6 +14,21 @@ from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
+# from surfactant.cmd.cli_commands.cli_load import Load
+from surfactant.cmd.cli_commands import *
+
+
+@click.argument("sbom", type=click.File("r"), required=True)
+@click.option(
+    "--input_format",
+    is_flag=False,
+    default="surfactant.input_readers.cytrics_reader",
+    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
+)
+@click.command("load")
+def handle_cli_load(sbom, input_format):
+    "CLI command to load supplied SBOM into cli"
+    Load(input_format=input_format).execute(sbom)
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -81,7 +99,7 @@ def handle_cli_find(sbom, output_format, input_format, **kwargs):
 
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = cli_find().execute(in_sbom, **filtered_kwargs)
+    out_sbom = find().execute(in_sbom, **filtered_kwargs)
     if not out_sbom.software:
         logger.warning("No software matches found with given parameters.")
     output_writer.write_sbom(out_sbom, sys.stdout)
@@ -126,7 +144,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
         in_sbom = input_reader.read_sbom(f)
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = cli_add().execute(in_sbom, **filtered_kwargs)
+    out_sbom = add().execute(in_sbom, **filtered_kwargs)
     # Write to the input file if no output specified
     if output is None:
         with open(Path(sbom), "w") as f:
@@ -143,6 +161,7 @@ def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
 @click.command("edit")
 def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
+    pass
 
 
 @click.argument("outfile", type=click.File("w"), required=True)
@@ -158,7 +177,6 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 def handle_cli_save(outfile, output_format):
     "CLI command to save SBOM to a user specified file"
     Save(output_format=output_format).execute(outfile)
-
 
 class cli_add:
     """

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,12 +1,9 @@
 import hashlib
 import sys
-import os
-import platform
 from pathlib import Path
 
 import click
 from loguru import logger
-import json
 
 from surfactant.cmd.cli_commands import Load, Save
 from surfactant.configmanager import ConfigManager
@@ -14,8 +11,6 @@ from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
-# from surfactant.cmd.cli_commands.cli_load import Load
-from surfactant.cmd.cli_commands import *
 
 
 @click.argument("sbom", type=click.File("r"), required=True)
@@ -162,6 +157,7 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 def handle_cli_save(outfile, output_format):
     "CLI command to save SBOM to a user specified file"
     Save(output_format=output_format).execute(outfile)
+
 
 class cli_add:
     """

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -1,37 +1,12 @@
 import sys
-import os
-import platform
-from pathlib import Path
 
 import click
 from loguru import logger
-import json
 
+from surfactant.cmd.cli_commands import Add, Find, Load, Merge, Save, Unload
 from surfactant.configmanager import ConfigManager
-from surfactant.cmd.cli_commands import *
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
-from surfactant.sbomtypes._relationship import Relationship
-from surfactant.sbomtypes._sbom import SBOM
-from surfactant.sbomtypes._software import Software
-from surfactant.cmd.cli_commands import *
 
-
-@click.argument("sbom", type=click.File("r"), required=True)
-@click.option(
-    "--input_format",
-    is_flag=False,
-    default="surfactant.input_readers.cytrics_reader",
-    help="SBOM input format, assumes that all input SBOMs being merged have the same format, options=[cytrics|cyclonedx|spdx]",
-)
-@click.command("load")
-def handle_cli_load(sbom, input_format):
-    "CLI command to load supplied SBOM into cli"
-    Load(input_format=input_format).execute(sbom)
-
-@click.command("unload")
-def handle_cli_unload():
-    "CLI command to load supplied SBOM into cli"
-    Unload().execute()
 
 @click.argument("sbom", type=click.File("r"), required=True)
 @click.option(
@@ -46,6 +21,12 @@ def handle_cli_unload():
 def handle_cli_load(sbom, input_format):
     "CLI command to load supplied SBOM into cli"
     Load(input_format=input_format).execute(sbom)
+
+
+@click.command("unload")
+def handle_cli_unload():
+    "CLI command to unload sbom from cli"
+    Unload().execute()
 
 
 @click.option("--file", is_flag=False, help="File of the entry to find")
@@ -72,8 +53,11 @@ def handle_cli_find(**kwargs):
     success = find.execute(**filtered_kwargs)
     # Write result to stdout in the cytrics format
     if success:
-        output_writer = find_io_plugin(get_plugin_manager(), "surfactant.output.cytrics_writer", "write_sbom")
+        output_writer = find_io_plugin(
+            get_plugin_manager(), "surfactant.output.cytrics_writer", "write_sbom"
+        )
         output_writer.write_sbom(find.get_subset(), sys.stdout)
+
 
 @click.option("--file", is_flag=False, help="Adds entry for file to sbom")
 @click.option("--relationship", is_flag=False, type=str, help="Adds relationship to sbom")
@@ -100,7 +84,8 @@ def handle_cli_add(**kwargs):
 @click.command("edit")
 def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     "CLI command to edit specific entry(s) in a supplied SBOM"
-    pass
+    logger.info("`surfactant cli edit` is not implemented yet.")
+
 
 @click.command("merge")
 def handle_cli_merge():
@@ -108,6 +93,7 @@ def handle_cli_merge():
     success = Merge().execute()
     if success:
         logger.info("Merge successful.")
+
 
 @click.argument("outfile", type=click.File("w"), required=True)
 @click.option(

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -13,7 +13,6 @@ from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.sbomtypes._relationship import Relationship
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.sbomtypes._software import Software
-# from surfactant.cmd.cli_commands.cli_load import Load
 from surfactant.cmd.cli_commands import *
 
 
@@ -29,6 +28,10 @@ def handle_cli_load(sbom, input_format):
     "CLI command to load supplied SBOM into cli"
     Load(input_format=input_format).execute(sbom)
 
+@click.command("unload")
+def handle_cli_unload():
+    "CLI command to load supplied SBOM into cli"
+    Unload().execute()
 
 @click.argument("sbom", type=click.File("r"), required=True)
 @click.option(
@@ -120,198 +123,3 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 def handle_cli_save(outfile, save_subset, output_format):
     "CLI command to save SBOM to a user specified file"
     Save(output_format=output_format).execute(outfile, save_subset)
-
-class cli_add:
-    """
-    A class that implements the surfactant cli add functionality
-
-    Attributes:
-    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
-    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
-    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
-    """
-
-    camel_case_conversions: dict
-    match_functions: dict
-    sbom: SBOM
-
-    def __init__(self):
-        """Initializes the cli_add class"""
-        self.match_functions = {
-            "relationship": self.add_relationship,
-            "file": self.add_file,
-            "installPath": self.add_installpath,
-            "entry": self.add_entry,
-        }
-        self.camel_case_conversions = {
-            "uuid": "UUID",
-            "filename": "fileName",
-            "installpath": "installPath",
-            "capturetime": "captureTime",
-            "relationshipassertion": "relationshipAssertion",
-        }
-
-    def handle_kwargs(self, kwargs: dict) -> dict:
-        converted_kwargs = {}
-        for k, v in kwargs.items():  # Convert key values to camelcase where appropriate
-            key = self.camel_case_conversions[k] if k in self.camel_case_conversions else k
-            converted_kwargs[key] = v
-        return converted_kwargs
-
-    def execute(self, input_sbom: SBOM, **kwargs):
-        """Executes the main functionality of the cli_find class
-        param: input_sbom   The sbom to add entries to
-        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
-        """
-        converted_kwargs = self.handle_kwargs(kwargs)
-        self.sbom = input_sbom
-
-        for key, value in converted_kwargs.items():
-            if key in self.match_functions:
-                self.match_functions[key](value)
-            else:
-                logger.warning(f"Paramter {key} is not supported")
-        return self.sbom
-
-    def add_relationship(self, value: dict) -> bool:
-        self.sbom.add_relationship(Relationship(**value))
-
-    def add_file(self, path):
-        self.sbom.software.append(Software.create_software_from_file(path))
-
-    def add_entry(self, entry):
-        self.sbom.software.append(Software.from_dict(entry))
-
-    def add_installpath(self, prefixes: tuple):
-        cleaned_prefixes = (p.rstrip("/") for p in prefixes)
-        containerPathPrefix, installPathPrefix = cleaned_prefixes
-        for sw in self.sbom.software:
-            for path in sw.containerPath:
-                if containerPathPrefix in path:
-                    sw.installPath.append(path.replace(containerPathPrefix, installPathPrefix))
-
-
-class cli_find:
-    """
-    A class that implements the surfactant cli find functionality
-
-    Attributes:
-    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
-    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
-    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
-    """
-
-    match_functions: dict
-    camel_case_conversions: dict
-    sbom: SBOM
-
-    def __init__(self):
-        """Initializes the cli_find class"""
-        self.match_functions = {
-            int: self.match_single_value,
-            str: self.match_single_value,
-            list: self.match_array_value,
-            dict: self.match_dict_value,
-            float: self.match_none_or_unhandled,
-            tuple: self.match_none_or_unhandled,
-            type(None): self.match_none_or_unhandled,
-        }
-        self.camel_case_conversions = {
-            "uuid": "UUID",
-            "filename": "fileName",
-            "containerpath": "containerPath",
-            "installpath": "installPath",
-            "capturetime": "captureTime",
-            "relationshipassertion": "relationshipAssertion",
-        }
-        self.sbom = SBOM()
-
-    def handle_kwargs(self, kwargs: dict) -> dict:
-        converted_kwargs = {}
-        for k, v in kwargs.items():  # Convert key values to camelcase where appropriate
-            if k == "file":
-                sha256, sha1, md5 = self._calculate_hashes(v, sha256=True, sha1=True, md5=True)
-                v = {"sha256": sha256, "sha1": sha1, "md5": md5}
-            key = self.camel_case_conversions[k] if k in self.camel_case_conversions else k
-            converted_kwargs[key] = v
-        return converted_kwargs
-
-    def execute(self, input_sbom: SBOM, **kwargs):
-        """Executes the main functionality of the cli_find class
-        param: input_sbom   The sbom to find matches within
-        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
-        """
-        converted_kwargs = self.handle_kwargs(kwargs)
-
-        for sw in input_sbom.software:
-            match = True
-            for k, v in converted_kwargs.items():
-                if k == "file":
-                    entry_value = {"sha256": sw.sha256, "sha1": sw.sha1, "md5": sw.md5}
-                else:
-                    entry_value = vars(sw)[k] if k in vars(sw) else None
-                if not self.match_functions[type(entry_value)](entry_value, v):
-                    match = False
-                    break
-            if match:
-                self.sbom.add_software(sw)
-        return self.sbom
-
-    def match_single_value(self, first, second) -> bool:
-        """Matches sbom entry on single value
-        param: first   The entry value to match
-        param: second: The value to match first to
-        returns:       bool, True if a match, False if not
-        """
-        if first == second:
-            return True
-        return False
-
-    def match_array_value(self, array, value) -> bool:
-        """Matches sbom entry on array value. Will match if value is contained in any of the array values.
-        param: entry    The entry array to match
-        param: value:   The value to find in array
-        returns:        bool, True if a match, False if not
-        """
-        if any(value in entry for entry in array):
-            return True
-        return False
-
-    def match_dict_value(self, d1: dict, d2: dict) -> bool:
-        """Matches dictonary values. Will match if two dictionaries have any k,v pairs in common. Used for file hash comparison.
-        param: d1       The first dictionary of values
-        param: d2:      The 2nd dictionary of values to find
-        returns:        bool, True if a match, False if not
-        """
-        if set(d1.items()).intersection(set(d2.items())):
-            return True
-        return False
-
-    def match_none_or_unhandled(self, value, match):
-        """Default match function if no key value found in SBOM or match type unknown/unhandled
-        param: value    Should only be None
-        param: match:   Value that would have been matched
-        returns:        False
-        """
-        logger.debug(f"SBOM entry_value of type={type(value)} is not currently handled.")
-        return False
-
-    def _calculate_hashes(self, file, sha256=False, sha1=False, md5=False):
-        """Helper function to calculate hashes on a given file.
-        param: file      The file to calculate hashes on
-        param: sha256:   Bool to decide if sha256 hash should be calculated
-        param: sha1:     Bool to decide if sha1 hash should be calculated
-        param: md5:      Bool to decide if md5 hash should be calculated
-        returns:         str, str, str, Hashes calculated, None for those that aren't calculated
-        """
-        sha256_hash, sha1_hash, md5_hash = None, None, None
-        with open(file, "rb") as f:
-            if sha256:
-                sha256_hash = hashlib.sha256(f.read()).hexdigest()
-                f.seek(0)
-            if sha1:
-                sha1_hash = hashlib.sha1(f.read()).hexdigest()
-                f.seek(0)
-            if md5:
-                md5_hash = hashlib.md5(f.read()).hexdigest()
-        return sha256_hash, sha1_hash, md5_hash

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -103,6 +103,12 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
 
 @click.argument("outfile", type=click.File("w"), required=True)
 @click.option(
+    "--save_subset",
+    is_flag=True,
+    default=False,
+    help="When True, cli will save subset, otherwise it will save full sbom",
+)
+@click.option(
     "--output_format",
     is_flag=False,
     default=ConfigManager().get(
@@ -111,9 +117,9 @@ def handle_cli_edit(sbom, output_format, input_format, **kwargs):
     help="SBOM output format, options=[cytrics|csv|spdx|cyclonedx]",
 )
 @click.command("save")
-def handle_cli_save(outfile, output_format):
+def handle_cli_save(outfile, save_subset, output_format):
     "CLI command to save SBOM to a user specified file"
-    Save(output_format=output_format).execute(outfile)
+    Save(output_format=output_format).execute(outfile, save_subset)
 
 class cli_add:
     """

--- a/surfactant/cmd/cli.py
+++ b/surfactant/cmd/cli.py
@@ -72,14 +72,6 @@ def handle_cli_find(**kwargs):
         output_writer = find_io_plugin(get_plugin_manager(), "surfactant.output.cytrics_writer", "write_sbom")
         output_writer.write_sbom(find.get_subset(), sys.stdout)
 
-
-@click.argument("sbom", required=True)
-@click.option(
-    "--output",
-    default=None,
-    is_flag=False,
-    help="Specifies the file to output new sbom. Default replaces the input file.",
-)
 @click.option("--file", is_flag=False, help="Adds entry for file to sbom")
 @click.option("--relationship", is_flag=False, type=str, help="Adds relationship to sbom")
 @click.option("--entry", is_flag=False, type=str, help="Adds software entry to sbom")
@@ -90,39 +82,16 @@ def handle_cli_find(**kwargs):
     nargs=2,
     help="Adds new installPath by finding and replacing a containerPath prefix (1st arg) with a new prefix (2nd arg)",
 )
-@click.option(
-    "--output_format",
-    is_flag=False,
-    default="surfactant.output.cytrics_writer",
-    help="SBOM output format, options=[cytrics|csv|spdx|cyclonedx]",
-)
-@click.option(
-    "--input_format",
-    is_flag=False,
-    default="surfactant.input_readers.cytrics_reader",
-    help="SBOM input format, options=[cytrics|cyclonedx|spdx]",
-)
 @click.command("add")
-def handle_cli_add(sbom, output, output_format, input_format, **kwargs):
+def handle_cli_add(**kwargs):
     "CLI command to add specific entry(s) to a supplied SBOM"
-    pm = get_plugin_manager()
-    output_writer = find_io_plugin(pm, output_format, "write_sbom")
-    input_reader = find_io_plugin(pm, input_format, "read_sbom")
-    with open(Path(sbom), "r") as f:
-        in_sbom = input_reader.read_sbom(f)
     # Remove None values
     filtered_kwargs = dict({(k, v) for k, v in kwargs.items() if v is not None})
-    out_sbom = add().execute(in_sbom, **filtered_kwargs)
-    # Write to the input file if no output specified
-    if output is None:
-        with open(Path(sbom), "w") as f:
-            output_writer.write_sbom(out_sbom, f)
-    else:
-        try:
-            with open(Path(output), "w") as f:
-                output_writer.write_sbom(out_sbom, f)
-        except OSError as e:
-            logger.error(f"Could not open file {output} in write mode - {e}")
+    add = Add()
+    success = add.execute(**filtered_kwargs)
+    # Write result to stdout in the cytrics format
+    if success:
+        logger.info("Changes successfully added.")
 
 
 @click.argument("sbom", type=click.File("r"), required=True)

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -6,6 +6,5 @@
 from .cli_base import Cli
 from .cli_load import Load
 from .cli_save import Save
-from .cli_base import Cli
 
 __all__ = ["Load", "Save", "Cli"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -9,5 +9,6 @@ from .cli_unload import Unload
 from .cli_save import Save
 from .cli_add import Add
 from .cli_find import Find
+from .cli_merge import Merge
 
-__all__ = ["Load", "Unload", "Save", "Cli", "Add", "Find"]
+__all__ = ["Load", "Unload", "Save", "Cli", "Add", "Find", "Merge"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -5,8 +5,9 @@
 
 from .cli_base import Cli
 from .cli_load import Load
+from .cli_unload import Unload
 from .cli_save import Save
 from .cli_add import Add
 from .cli_find import Find
 
-__all__ = ["Load", "Save", "Cli", "Add", "Find"]
+__all__ = ["Load", "Unload", "Save", "Cli", "Add", "Find"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -6,5 +6,6 @@
 from .cli_base import Cli
 from .cli_load import Load
 from .cli_save import Save
+from .cli_base import Cli
 
 __all__ = ["Load", "Save", "Cli"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -6,5 +6,7 @@
 from .cli_base import Cli
 from .cli_load import Load
 from .cli_save import Save
+from .cli_add import Add
+from .cli_find import Find
 
-__all__ = ["Load", "Save", "Cli"]
+__all__ = ["Load", "Save", "Cli", "Add", "Find"]

--- a/surfactant/cmd/cli_commands/__init__.py
+++ b/surfactant/cmd/cli_commands/__init__.py
@@ -3,12 +3,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-from .cli_base import Cli
-from .cli_load import Load
-from .cli_unload import Unload
-from .cli_save import Save
 from .cli_add import Add
+from .cli_base import Cli
 from .cli_find import Find
+from .cli_load import Load
 from .cli_merge import Merge
+from .cli_save import Save
+from .cli_unload import Unload
 
 __all__ = ["Load", "Unload", "Save", "Cli", "Add", "Find", "Merge"]

--- a/surfactant/cmd/cli_commands/cli_add.py
+++ b/surfactant/cmd/cli_commands/cli_add.py
@@ -1,0 +1,69 @@
+from loguru import logger
+
+from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.sbomtypes._sbom import SBOM
+
+class Add(Cli):
+    """
+    A class that implements the surfactant cli add functionality
+
+    Attributes:
+    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
+    """
+
+    def __init__(self):
+        """Initializes the cli_add class"""
+        self.match_functions = {
+            "relationship": self.add_relationship,
+            "file": self.add_file,
+            "installPath": self.add_installpath,
+            "entry": self.add_entry,
+        }
+        self.camel_case_conversions = {
+            "uuid": "UUID",
+            "filename": "fileName",
+            "installpath": "installPath",
+            "capturetime": "captureTime",
+            "relationshipassertion": "relationshipAssertion",
+        }
+
+    def handle_kwargs(self, kwargs: dict) -> dict:
+        converted_kwargs = {}
+        for k, v in kwargs.items():  # Convert key values to camelcase where appropriate
+            key = self.camel_case_conversions[k] if k in self.camel_case_conversions else k
+            converted_kwargs[key] = v
+        return converted_kwargs
+
+    def execute(self, input_sbom: SBOM, **kwargs):
+        """Executes the main functionality of the cli_find class
+        param: input_sbom   The sbom to add entries to
+        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
+        """
+        converted_kwargs = self.handle_kwargs(kwargs)
+        self.sbom = input_sbom
+
+        for key, value in converted_kwargs.items():
+            if key in self.match_functions:
+                self.match_functions[key](value)
+            else:
+                logger.warning(f"Parameter {key} is not supported")
+        return self.sbom
+
+    def add_relationship(self, value: dict) -> bool:
+        self.sbom.add_relationship(Relationship(**value))
+
+    def add_file(self, path):
+        self.sbom.software.append(Software.create_software_from_file(path))
+
+    def add_entry(self, entry):
+        self.sbom.software.append(Software.from_dict(entry))
+
+    def add_installpath(self, prefixes: tuple):
+        cleaned_prefixes = (p.rstrip("/") for p in prefixes)
+        containerPathPrefix, installPathPrefix = cleaned_prefixes
+        for sw in self.sbom.software:
+            for path in sw.containerPath:
+                if containerPathPrefix in path:
+                    sw.installPath.append(path.replace(containerPathPrefix, installPathPrefix))

--- a/surfactant/cmd/cli_commands/cli_add.py
+++ b/surfactant/cmd/cli_commands/cli_add.py
@@ -1,8 +1,8 @@
 from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
-from surfactant.sbomtypes import SBOM
-from surfactant.sbomtypes import Software
+from surfactant.sbomtypes import SBOM, Relationship, Software
+
 
 class Add(Cli):
     """
@@ -29,7 +29,7 @@ class Add(Cli):
             "capturetime": "captureTime",
             "relationshipassertion": "relationshipAssertion",
         }
-        super(Add, self).__init__()
+        super().__init__()
 
     def handle_kwargs(self, kwargs: dict) -> dict:
         converted_kwargs = {}
@@ -49,11 +49,10 @@ class Add(Cli):
             if not self.sbom:
                 logger.error("No sbom currently loaded. Load an sbom with `surfactant cli load`")
                 return False
-            else:
-                working_sbom = self.sbom
+            working_sbom = self.sbom
         else:
             working_sbom = self.subset
-            
+
         converted_kwargs = self.handle_kwargs(kwargs)
 
         for key, value in converted_kwargs.items():

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -5,6 +5,12 @@ from dataclasses import Field
 from loguru import logger
 
 from surfactant.configmanager import ConfigManager
+from pathlib import Path
+import json
+import os
+import platform
+from loguru import logger
+
 from surfactant.sbomtypes._sbom import SBOM
 
 
@@ -28,7 +34,7 @@ class Cli:
     subset_filename: str
     match_functions: dict
     camel_case_conversions: dict
-
+    
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -30,7 +30,7 @@ class Cli:
     subset_filename: str
     match_functions: dict
     camel_case_conversions: dict
-
+    
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -128,4 +128,9 @@ class Cli:
         """Gets the subset attribute"""
         return self.subset
 
+    def delete_subset(self):
+        """Deletes the subset attribute"""
+        subset_path = Path(self.data_dir, self.subset_filename)
+        if os.path.exists(subset_path):
+            os.remove(subset_path)
 

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -108,14 +108,16 @@ class Cli:
             return None
 
     def save_changes(self):
-        """Serializes the sbom and saves it in the designated directory"""
-        with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
-            f.write(self.serialize(self.sbom))
-    
-    def save_subset(self):
-        """Serializes the sbom subset and saves it in the designated directory"""
-        with open(Path(self.data_dir, self.subset_filename), "wb") as f:
-            f.write(self.serialize(self.subset))
+        """Saves changes made to the working sbom by serializing and storing on the filesystem"""
+        # Save full sbom
+        if self.sbom is not None:
+            with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
+                f.write(self.serialize(self.sbom))
+        
+        # Save subset
+        if self.subset is not None:
+            with open(Path(self.data_dir, self.subset_filename), "wb") as f:
+                f.write(self.serialize(self.subset))
 
     def get_sbom(self):
         """Gets the sbom attribute"""

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -3,7 +3,7 @@ import pickle
 import platform
 from dataclasses import Field
 from pathlib import Path
-import dataclasses
+
 from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -34,6 +34,8 @@ class Cli:
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"
+        self.sbom = None
+        self.subset = None
         # Create data directory
         self.data_dir = ConfigManager().get_data_dir_path()
         self.data_dir.mkdir(parents=True, exist_ok=True)
@@ -79,3 +81,48 @@ class Cli:
         except pickle.UnpicklingError as e:
             logger.error(f"Could not deserialize sbom from given data - {e}")
             return None
+    
+    def load_current_sbom(self) -> SBOM:
+        """Deserializes the currently loaded sbom for use within the cli command
+
+        Returns:
+            SBOM: A SBOM instance.
+        """
+        try:
+            with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
+                return self.deserialize(f.read())
+        except FileNotFoundError:
+            return None
+    
+    def load_current_subset(self) -> SBOM:
+        """Deserializes the currently loaded subset sbom for use within the cli command
+
+        Returns:
+            SBOM: A SBOM instance.
+        """
+        try: 
+            with open(Path(self.data_dir, self.subset_filename), "rb") as f:
+                return self.deserialize(f.read())
+        except FileNotFoundError:
+            logger.warning("No subset sbom exists.")
+            return None
+
+    def save_changes(self):
+        """Serializes the sbom and saves it in the designated directory"""
+        with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
+            f.write(self.serialize(self.sbom))
+    
+    def save_subset(self):
+        """Serializes the sbom subset and saves it in the designated directory"""
+        with open(Path(self.data_dir, self.subset_filename), "wb") as f:
+            f.write(self.serialize(self.subset))
+
+    def get_sbom(self):
+        """Gets the sbom attribute"""
+        return self.sbom
+
+    def get_subset(self):
+        """Gets the subset attribute"""
+        return self.subset
+
+

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 from loguru import logger
+from types import MappingProxyType
 
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.configmanager import ConfigManager

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,12 +1,9 @@
 import dataclasses
 import pickle
+import platform
 from dataclasses import Field
 from pathlib import Path
-import json
-import os
-import platform
-from types import MappingProxyType
-
+import dataclasses
 from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -30,7 +30,7 @@ class Cli:
     subset_filename: str
     match_functions: dict
     camel_case_conversions: dict
-    
+
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"
@@ -81,7 +81,7 @@ class Cli:
         except pickle.UnpicklingError as e:
             logger.error(f"Could not deserialize sbom from given data - {e}")
             return None
-    
+
     def load_current_sbom(self) -> SBOM:
         """Deserializes the currently loaded sbom for use within the cli command
 
@@ -94,14 +94,14 @@ class Cli:
         except FileNotFoundError:
             logger.debug("No sbom loaded.")
             return None
-    
+
     def load_current_subset(self) -> SBOM:
         """Deserializes the currently loaded subset sbom for use within the cli command
 
         Returns:
             SBOM: A SBOM instance.
         """
-        try: 
+        try:
             with open(Path(self.data_dir, self.subset_filename), "rb") as f:
                 return self.deserialize(f.read())
         except FileNotFoundError:
@@ -114,7 +114,7 @@ class Cli:
         if self.sbom is not None:
             with open(Path(self.data_dir, self.sbom_filename), "wb") as f:
                 f.write(self.serialize(self.sbom))
-        
+
         # Save subset
         if self.subset is not None:
             with open(Path(self.data_dir, self.subset_filename), "wb") as f:
@@ -133,4 +133,3 @@ class Cli:
         subset_path = Path(self.data_dir, self.subset_filename)
         if os.path.exists(subset_path):
             os.remove(subset_path)
-

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -92,6 +92,7 @@ class Cli:
             with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
                 return self.deserialize(f.read())
         except FileNotFoundError:
+            logger.debug("No sbom loaded.")
             return None
     
     def load_current_subset(self) -> SBOM:
@@ -104,7 +105,7 @@ class Cli:
             with open(Path(self.data_dir, self.subset_filename), "rb") as f:
                 return self.deserialize(f.read())
         except FileNotFoundError:
-            logger.warning("No subset sbom exists.")
+            logger.debug("No subset sbom exists.")
             return None
 
     def save_changes(self):

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,13 +1,13 @@
 import dataclasses
+import os
 import pickle
-import platform
 from dataclasses import Field
 from pathlib import Path
 
 from loguru import logger
 
-from surfactant.sbomtypes._sbom import SBOM
 from surfactant.configmanager import ConfigManager
+from surfactant.sbomtypes._sbom import SBOM
 
 
 class Cli:

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -1,10 +1,6 @@
 import dataclasses
 import pickle
 from dataclasses import Field
-
-from loguru import logger
-
-from surfactant.configmanager import ConfigManager
 from pathlib import Path
 import json
 import os
@@ -12,6 +8,7 @@ import platform
 from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM
+from surfactant.configmanager import ConfigManager
 
 
 class Cli:
@@ -34,7 +31,7 @@ class Cli:
     subset_filename: str
     match_functions: dict
     camel_case_conversions: dict
-    
+
     def __init__(self):
         self.sbom_filename = "sbom_cli"
         self.subset_filename = "subset_cli"

--- a/surfactant/cmd/cli_commands/cli_base.py
+++ b/surfactant/cmd/cli_commands/cli_base.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import json
 import os
 import platform
-from loguru import logger
 from types import MappingProxyType
+
+from loguru import logger
 
 from surfactant.sbomtypes._sbom import SBOM
 from surfactant.configmanager import ConfigManager

--- a/surfactant/cmd/cli_commands/cli_find.py
+++ b/surfactant/cmd/cli_commands/cli_find.py
@@ -1,0 +1,136 @@
+from loguru import logger
+import hashlib
+
+from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.sbomtypes._sbom import SBOM
+
+class Find(Cli):
+    """
+    A class that implements the surfactant cli find functionality
+
+    Attributes:
+    match_functions         A dictionary of functions that provide matching functionality for given SBOM fields (i.e. uuid, sha256, installpath, etc)
+    camel_case_conversions  A dictionary of string conversions from all lowercase to camelcase. Used to convert python click options to match the SBOM attribute's case
+    sbom                    An internal record of sbom entries the class adds to as it finds more matches.
+    """
+
+    def __init__(self):
+        """Initializes the cli_find class"""
+        self.match_functions = {
+            int: self.match_single_value,
+            str: self.match_single_value,
+            list: self.match_array_value,
+            dict: self.match_dict_value,
+            float: self.match_none_or_unhandled,
+            tuple: self.match_none_or_unhandled,
+            type(None): self.match_none_or_unhandled,
+        }
+        self.camel_case_conversions = {
+            "uuid": "UUID",
+            "filename": "fileName",
+            "containerpath": "containerPath",
+            "installpath": "installPath",
+            "capturetime": "captureTime",
+            "relationshipassertion": "relationshipAssertion",
+        }
+        super(Find, self).__init__()
+
+    def handle_kwargs(self, kwargs: dict) -> dict:
+        converted_kwargs = {}
+        for k, v in kwargs.items():  # Convert key values to camelcase where appropriate
+            if k == "file":
+                sha256, sha1, md5 = self._calculate_hashes(v, sha256=True, sha1=True, md5=True)
+                v = {"sha256": sha256, "sha1": sha1, "md5": md5}
+            key = self.camel_case_conversions[k] if k in self.camel_case_conversions else k
+            converted_kwargs[key] = v
+        return converted_kwargs
+
+    def execute(self, **kwargs):
+        """Executes the main functionality of the cli_find class
+        param: self.sbom   The sbom to find matches within
+        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
+        """
+        self.sbom = self.load_current_sbom()
+        if not self.sbom:
+            logger.error("No sbom currently loaded. Load an sbom with `surfactant cli load`")
+            return False
+        self.subset = SBOM()
+
+        converted_kwargs = self.handle_kwargs(kwargs)
+
+        for sw in self.sbom.software:
+            match = True
+            for k, v in converted_kwargs.items():
+                if k == "file":
+                    entry_value = {"sha256": sw.sha256, "sha1": sw.sha1, "md5": sw.md5}
+                else:
+                    entry_value = vars(sw)[k] if k in vars(sw) else None
+                if not self.match_functions[type(entry_value)](entry_value, v):
+                    match = False
+                    break
+            if match:
+                self.subset.add_software(sw)
+        if not self.subset.software:
+            logger.warning("No software matches found with given parameters.")
+            return False
+        self.save_subset()
+        return True
+
+    def match_single_value(self, first, second) -> bool:
+        """Matches sbom entry on single value
+        param: first   The entry value to match
+        param: second: The value to match first to
+        returns:       bool, True if a match, False if not
+        """
+        if first == second:
+            return True
+        return False
+
+    def match_array_value(self, array, value) -> bool:
+        """Matches sbom entry on array value. Will match if value is contained in any of the array values.
+        param: entry    The entry array to match
+        param: value:   The value to find in array
+        returns:        bool, True if a match, False if not
+        """
+        if any(value in entry for entry in array):
+            return True
+        return False
+
+    def match_dict_value(self, d1: dict, d2: dict) -> bool:
+        """Matches dictonary values. Will match if two dictionaries have any k,v pairs in common. Used for file hash comparison.
+        param: d1       The first dictionary of values
+        param: d2:      The 2nd dictionary of values to find
+        returns:        bool, True if a match, False if not
+        """
+        if set(d1.items()).intersection(set(d2.items())):
+            return True
+        return False
+
+    def match_none_or_unhandled(self, value, match):
+        """Default match function if no key value found in SBOM or match type unknown/unhandled
+        param: value    Should only be None
+        param: match:   Value that would have been matched
+        returns:        False
+        """
+        logger.debug(f"SBOM entry_value of type={type(value)} is not currently handled.")
+        return False
+
+    def _calculate_hashes(self, file, sha256=False, sha1=False, md5=False):
+        """Helper function to calculate hashes on a given file.
+        param: file      The file to calculate hashes on
+        param: sha256:   Bool to decide if sha256 hash should be calculated
+        param: sha1:     Bool to decide if sha1 hash should be calculated
+        param: md5:      Bool to decide if md5 hash should be calculated
+        returns:         str, str, str, Hashes calculated, None for those that aren't calculated
+        """
+        sha256_hash, sha1_hash, md5_hash = None, None, None
+        with open(file, "rb") as f:
+            if sha256:
+                sha256_hash = hashlib.sha256(f.read()).hexdigest()
+                f.seek(0)
+            if sha1:
+                sha1_hash = hashlib.sha1(f.read()).hexdigest()
+                f.seek(0)
+            if md5:
+                md5_hash = hashlib.md5(f.read()).hexdigest()
+        return sha256_hash, sha1_hash, md5_hash

--- a/surfactant/cmd/cli_commands/cli_find.py
+++ b/surfactant/cmd/cli_commands/cli_find.py
@@ -47,7 +47,6 @@ class Find(Cli):
 
     def execute(self, **kwargs):
         """Executes the main functionality of the cli_find class
-        param: self.sbom   The sbom to find matches within
         param: kwargs:      Dictionary of key/value pairs indicating what features to match on
         """
         self.sbom = self.load_current_sbom()
@@ -73,7 +72,7 @@ class Find(Cli):
         if not self.subset.software:
             logger.warning("No software matches found with given parameters.")
             return False
-        self.save_subset()
+        self.save_changes()
         return True
 
     def match_single_value(self, first, second) -> bool:

--- a/surfactant/cmd/cli_commands/cli_find.py
+++ b/surfactant/cmd/cli_commands/cli_find.py
@@ -1,8 +1,10 @@
-from loguru import logger
 import hashlib
+
+from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.sbomtypes._sbom import SBOM
+
 
 class Find(Cli):
     """
@@ -33,7 +35,7 @@ class Find(Cli):
             "capturetime": "captureTime",
             "relationshipassertion": "relationshipAssertion",
         }
-        super(Find, self).__init__()
+        super().__init__()
 
     def handle_kwargs(self, kwargs: dict) -> dict:
         converted_kwargs = {}

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -11,6 +11,7 @@ class Load(Cli):
     Attributes:
         input_format (str): The format for input sboms
     """
+
     def __init__(self, *args, input_format, **kwargs):
         """Executes the load class constructor
 

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -11,7 +11,6 @@ class Load(Cli):
     Attributes:
         input_format (str): The format for input sboms
     """
-
     def __init__(self, *args, input_format, **kwargs):
         """Executes the load class constructor
 

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -1,8 +1,8 @@
+from loguru import logger
 from pathlib import Path
 
-from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
-
+from surfactant.cmd.cli_commands.cli_base import Cli
 
 class Load(Cli):
     """

--- a/surfactant/cmd/cli_commands/cli_load.py
+++ b/surfactant/cmd/cli_commands/cli_load.py
@@ -1,8 +1,8 @@
-from loguru import logger
 from pathlib import Path
 
-from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+
 
 class Load(Cli):
     """

--- a/surfactant/cmd/cli_commands/cli_merge.py
+++ b/surfactant/cmd/cli_commands/cli_merge.py
@@ -2,14 +2,11 @@ from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
 
+
 class Merge(Cli):
     """
     A class that implements the surfactant cli merge functionality
     """
-
-    def __init__(self):
-        """Initializes the cli_merge class"""
-        super(Merge, self).__init__()
 
     def execute(self, **kwargs):
         """Executes the main functionality of the cli_merge class
@@ -23,11 +20,8 @@ class Merge(Cli):
         if not self.subset:
             logger.warning("No subset to merge into main sbom")
             return False
-        
+
         self.sbom.merge(self.subset)
         self.save_changes()
         self.delete_subset()
         return True
-        
-        
-        

--- a/surfactant/cmd/cli_commands/cli_merge.py
+++ b/surfactant/cmd/cli_commands/cli_merge.py
@@ -1,0 +1,33 @@
+from loguru import logger
+
+from surfactant.cmd.cli_commands.cli_base import Cli
+
+class Merge(Cli):
+    """
+    A class that implements the surfactant cli merge functionality
+    """
+
+    def __init__(self):
+        """Initializes the cli_find class"""
+        super().__init__(*args, **kwargs)
+
+    def execute(self, **kwargs):
+        """Executes the main functionality of the cli_find class
+        param: kwargs:      Dictionary of key/value pairs indicating what features to match on
+        """
+        self.sbom = self.load_current_sbom()
+        self.subset = self.load_current_subset()
+        if not self.sbom:
+            logger.error("No sbom currently loaded. Load an sbom with `surfactant cli load`")
+            return False
+        if not self.subset:
+            logger.warning("No subset to merge into main sbom")
+            return False
+        
+        self.sbom.merge(self.subset)
+        self.save_changes()
+        self.delete_subset()
+        return True
+        
+        
+        

--- a/surfactant/cmd/cli_commands/cli_merge.py
+++ b/surfactant/cmd/cli_commands/cli_merge.py
@@ -8,11 +8,11 @@ class Merge(Cli):
     """
 
     def __init__(self):
-        """Initializes the cli_find class"""
-        super().__init__(*args, **kwargs)
+        """Initializes the cli_merge class"""
+        super(Merge, self).__init__()
 
     def execute(self, **kwargs):
-        """Executes the main functionality of the cli_find class
+        """Executes the main functionality of the cli_merge class
         param: kwargs:      Dictionary of key/value pairs indicating what features to match on
         """
         self.sbom = self.load_current_sbom()

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -20,7 +20,7 @@ class Save(Cli):
         self.output_format = output_format
         super().__init__(*args, **kwargs)
 
-    def execute(self, output_file):
+    def execute(self, output_file, save_subset):
         """Executes the main functionality of the load class
 
         Args:
@@ -28,7 +28,11 @@ class Save(Cli):
         """
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
-        with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
-            data = f.read()
+        if save_subset:
+            with open(Path(self.data_dir, self.subset_filename), "rb") as f:
+                data = f.read()
+        else:
+            with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
+                data = f.read()
         self.sbom = Cli.deserialize(data)
         output_writer.write_sbom(self.sbom, output_file)

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,8 +1,8 @@
-from loguru import logger
 from pathlib import Path
 
-from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 from surfactant.cmd.cli_commands.cli_base import Cli
+from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
+
 
 class Save(Cli):
     """
@@ -29,7 +29,6 @@ class Save(Cli):
         """
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
-
         with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
             data = f.read()
         self.sbom = Cli.deserialize(data)

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from surfactant.sbomtypes._sbom import SBOM
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from surfactant.sbomtypes._sbom import SBOM
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
 

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -11,7 +11,6 @@ class Save(Cli):
     Attributes:
         output_format (str): The format of the sbom to be outputted
     """
-
     def __init__(self, *args, output_format, **kwargs):
         """Executes the load class constructor
 

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,8 +1,8 @@
+from loguru import logger
 from pathlib import Path
 
-from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
-
+from surfactant.cmd.cli_commands.cli_base import Cli
 
 class Save(Cli):
     """

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
 from surfactant.plugin.manager import find_io_plugin, get_plugin_manager
@@ -29,10 +30,11 @@ class Save(Cli):
         pm = get_plugin_manager()
         output_writer = find_io_plugin(pm, self.output_format, "write_sbom")
         if save_subset:
-            with open(Path(self.data_dir, self.subset_filename), "rb") as f:
-                data = f.read()
+            self.sbom = self.load_current_subset()
         else:
-            with open(Path(self.data_dir, self.sbom_filename), "rb") as f:
-                data = f.read()
-        self.sbom = Cli.deserialize(data)
-        output_writer.write_sbom(self.sbom, output_file)
+            self.sbom = self.load_current_sbom()
+        if self.sbom :
+            output_writer.write_sbom(self.sbom, output_file)
+            return
+        logger.error("Failed to save sbom - no data found")
+        

--- a/surfactant/cmd/cli_commands/cli_save.py
+++ b/surfactant/cmd/cli_commands/cli_save.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
@@ -12,6 +11,7 @@ class Save(Cli):
     Attributes:
         output_format (str): The format of the sbom to be outputted
     """
+
     def __init__(self, *args, output_format, **kwargs):
         """Executes the load class constructor
 
@@ -33,8 +33,7 @@ class Save(Cli):
             self.sbom = self.load_current_subset()
         else:
             self.sbom = self.load_current_sbom()
-        if self.sbom :
+        if self.sbom:
             output_writer.write_sbom(self.sbom, output_file)
             return
         logger.error("Failed to save sbom - no data found")
-        

--- a/surfactant/cmd/cli_commands/cli_unload.py
+++ b/surfactant/cmd/cli_commands/cli_unload.py
@@ -1,6 +1,7 @@
 import os
-from loguru import logger
 from pathlib import Path
+
+from loguru import logger
 
 from surfactant.cmd.cli_commands.cli_base import Cli
 
@@ -10,18 +11,13 @@ class Unload(Cli):
     A class that implements the surfactant cli unload functionality
 
     """
-    def __init__(self, *args, **kwargs):
-        """Executes the unload class constructor
-        """
-        super().__init__(*args, **kwargs)
 
     def execute(self):
-        """Executes the main functionality of the unload class
-        """
+        """Executes the main functionality of the unload class"""
         sbom_path = Path(self.data_dir, self.sbom_filename)
         subset_path = Path(self.data_dir, self.subset_filename)
         if not os.path.exists(sbom_path):
-            logger.info(f"No sbom loaded, nothing to unload")
+            logger.info("No sbom loaded, nothing to unload")
         else:
             os.remove(sbom_path)
         if os.path.exists(subset_path):

--- a/surfactant/cmd/cli_commands/cli_unload.py
+++ b/surfactant/cmd/cli_commands/cli_unload.py
@@ -1,0 +1,28 @@
+import os
+from loguru import logger
+from pathlib import Path
+
+from surfactant.cmd.cli_commands.cli_base import Cli
+
+
+class Unload(Cli):
+    """
+    A class that implements the surfactant cli unload functionality
+
+    """
+    def __init__(self, *args, **kwargs):
+        """Executes the unload class constructor
+        """
+        super().__init__(*args, **kwargs)
+
+    def execute(self):
+        """Executes the main functionality of the unload class
+        """
+        sbom_path = Path(self.data_dir, self.sbom_filename)
+        subset_path = Path(self.data_dir, self.subset_filename)
+        if not os.path.exists(sbom_path):
+            logger.info(f"No sbom loaded, nothing to unload")
+        else:
+            os.remove(sbom_path)
+        if os.path.exists(subset_path):
+            os.remove(subset_path)

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -7,9 +7,8 @@ import pathlib
 
 import pytest
 
-from surfactant.cmd.cli import cli_add, cli_find
-from surfactant.cmd.cli_commands import Cli
-from surfactant.sbomtypes import SBOM, Relationship
+from surfactant.cmd.cli_commands import Cli, Find, Load
+from surfactant.sbomtypes import SBOM
 
 
 @pytest.fixture(name="test_sbom")
@@ -69,116 +68,124 @@ bad_sbom = SBOM(
 )
 
 
-def test_find_by_sha256(test_sbom):
-    out_bom = cli_find().execute(
-        test_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
-    )
-    assert len(out_bom.software) == 1
-    assert (
-        out_bom.software[0].sha256
-        == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
-    )
-
-
-def test_find_by_multiple_hashes(test_sbom):
-    out_bom = cli_find().execute(
-        test_sbom,
-        sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
-        md5="5fbf80df5004db2f0ce1f78b524024fe",
-    )
-    assert len(out_bom.software) == 1
-    assert (
-        out_bom.software[0].sha256
-        == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
-    )
-
-
-def test_find_by_mismatched_hashes(test_sbom):
-    out_bom = cli_find().execute(
-        test_sbom,
-        sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
-        md5="2ff380e740d2eb09e5d67f6f2cd17636",
-    )
-    assert len(out_bom.software) == 0
-
-
-def test_find_by_containerPath(test_sbom):
-    out_bom = cli_find().execute(test_sbom, containerpath="477da45b-bb38-450e-93f7-e525aaaa6862/")
-    assert len(out_bom.software) == 7
-
-
-def test_find_with_malformed_sbom():
-    out_bom = cli_find().execute(bad_sbom, bad_key=1.24553)  # Unsupported Type
-    assert len(out_bom.software) == 0
-    out_bom = cli_find().execute(bad_sbom, bad_key="testing")  # Supported Type
-    assert len(out_bom.software) == 0
-
-
-def test_find_with_bad_filter():
-    out_bom = cli_find().execute(bad_sbom, bad_filter="testing")  # Supported Type
-    assert len(out_bom.software) == 0
-    out_bom = cli_find().execute(bad_sbom, bad_filter=1.234)  # Unsupported Type
-    assert len(out_bom.software) == 0
-
-
-def test_add_by_file(test_sbom):
-    previous_software_len = len(test_sbom.software)
-    out_bom = cli_add().execute(
-        test_sbom, file=pathlib.Path(__file__).parent / "../data/a_out_files/big_m68020.aout"
-    )
-    assert len(out_bom.software) == previous_software_len + 1
-    assert (
-        out_bom.software[8].sha256
-        == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
-    )
-
-
-def test_add_entry(test_sbom):
-    entry = {
-        "UUID": "6b50c545-3e07-4aec-bbb0-bae07704143a",
-        "name": "Test Aout File",
-        "size": 4,
-        "fileName": ["big_m68020.aout"],
-        "installPath": [],
-        "containerPath": [],
-        "captureTime": 1715726918,
-        "sha1": "fbf8688fbe1976b6f324b0028c4b97137ae9139d",
-        "sha256": "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4",
-        "md5": "e8d3808a4e311a4262563f3cb3a31c3e",
-        "comments": "This is a test entry.",
-    }
-    previous_software_len = len(test_sbom.software)
-    out_bom = cli_add().execute(test_sbom, entry=entry)
-    assert len(out_bom.software) == previous_software_len + 1
-    assert (
-        out_bom.software[8].sha256
-        == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
-    )
-
-
-def test_add_relationship(test_sbom):
-    relationship = {
-        "xUUID": "455341bb-2739-4918-9805-e1a93e27e2a4",
-        "yUUID": "e286a415-6c6b-427d-9fe6-d7dbb0486f7d",
-        "relationship": "Uses",
-    }
-    previous_rel_len = len(test_sbom.relationships)
-    out_bom = cli_add().execute(test_sbom, relationship=relationship)
-    assert len(out_bom.relationships) == previous_rel_len + 1
-    test_sbom.relationships.discard(Relationship(**relationship))
-
-
-def test_add_installpath(test_sbom):
-    containerPathPrefix = "477da45b-bb38-450e-93f7-e525aaaa6862/"
-    installPathPrefix = "/bin/"
-    out_bom = cli_add().execute(test_sbom, installpath=(containerPathPrefix, installPathPrefix))
-    for sw in out_bom.software:
-        if containerPathPrefix in sw.containerPath:
-            assert installPathPrefix in sw.installPath
-
-
+# Cli Base Class Unit Tests
 def test_cli_base_serialization(test_sbom):
     serialized = Cli.serialize(test_sbom)
     deserialized = Cli.deserialize(serialized)
     assert test_sbom == deserialized
     assert _compare_sboms(test_sbom, deserialized)
+
+
+def test_load_sbom(test_sbom):
+    Load(input_format="surfactant.input_readers.cytrics_reader").execute(test_sbom)
+
+
+def test_find_by_sha256(test_sbom):
+    find = Find()
+    success = find.execute(
+        sbom=test_sbom, sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    )
+    assert success
+    out_bom = find.get_subset()
+    assert len(out_bom.software) == 1
+    assert (
+        out_bom.software[0].sha256
+        == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+    )
+
+
+# def test_find_by_multiple_hashes(test_sbom):
+#     out_bom = Find().execute(
+#         test_sbom,
+#         sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+#         md5="5fbf80df5004db2f0ce1f78b524024fe",
+#     )
+#     assert len(out_bom.software) == 1
+#     assert (
+#         out_bom.software[0].sha256
+#         == "f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9"
+#     )
+
+
+# def test_find_by_mismatched_hashes(test_sbom):
+#     out_bom = Find().execute(
+#         test_sbom,
+#         sha256="f41ca6f7c447225df3a7eef754d303d22cf877586735fb2d56d1eb15bf1daed9",
+#         md5="2ff380e740d2eb09e5d67f6f2cd17636",
+#     )
+#     assert len(out_bom.software) == 0
+
+
+# def test_find_by_containerPath(test_sbom):
+#     out_bom = Find().execute(test_sbom, containerpath="477da45b-bb38-450e-93f7-e525aaaa6862/")
+#     assert len(out_bom.software) == 7
+
+
+# def test_find_with_malformed_sbom():
+#     out_bom = Find().execute(bad_sbom, bad_key=1.24553)  # Unsupported Type
+#     assert len(out_bom.software) == 0
+#     out_bom = Find().execute(bad_sbom, bad_key="testing")  # Supported Type
+#     assert len(out_bom.software) == 0
+
+
+# def test_find_with_bad_filter():
+#     out_bom = Find().execute(bad_sbom, bad_filter="testing")  # Supported Type
+#     assert len(out_bom.software) == 0
+#     out_bom = Find().execute(bad_sbom, bad_filter=1.234)  # Unsupported Type
+#     assert len(out_bom.software) == 0
+
+
+# def test_add_by_file(test_sbom):
+#     previous_software_len = len(test_sbom.software)
+#     out_bom = Add().execute(
+#         test_sbom, file=pathlib.Path(__file__).parent / "../data/a_out_files/big_m68020.aout"
+#     )
+#     assert len(out_bom.software) == previous_software_len + 1
+#     assert (
+#         out_bom.software[8].sha256
+#         == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
+#     )
+
+
+# def test_add_entry(test_sbom):
+#     entry = {
+#         "UUID": "6b50c545-3e07-4aec-bbb0-bae07704143a",
+#         "name": "Test Aout File",
+#         "size": 4,
+#         "fileName": ["big_m68020.aout"],
+#         "installPath": [],
+#         "containerPath": [],
+#         "captureTime": 1715726918,
+#         "sha1": "fbf8688fbe1976b6f324b0028c4b97137ae9139d",
+#         "sha256": "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4",
+#         "md5": "e8d3808a4e311a4262563f3cb3a31c3e",
+#         "comments": "This is a test entry.",
+#     }
+#     previous_software_len = len(test_sbom.software)
+#     out_bom = Add().execute(test_sbom, entry=entry)
+#     assert len(out_bom.software) == previous_software_len + 1
+#     assert (
+#         out_bom.software[8].sha256
+#         == "9e125f97e5f180717096c57fa2fdf06e71cea3e48bc33392318643306b113da4"
+#     )
+
+
+# def test_add_relationship(test_sbom):
+#     relationship = {
+#         "xUUID": "455341bb-2739-4918-9805-e1a93e27e2a4",
+#         "yUUID": "e286a415-6c6b-427d-9fe6-d7dbb0486f7d",
+#         "relationship": "Uses",
+#     }
+#     previous_rel_len = len(test_sbom.relationships)
+#     out_bom = Add().execute(test_sbom, relationship=relationship)
+#     assert len(out_bom.relationships) == previous_rel_len + 1
+#     test_sbom.relationships.discard(Relationship(**relationship))
+
+
+# def test_add_installpath(test_sbom):
+#     containerPathPrefix = "477da45b-bb38-450e-93f7-e525aaaa6862/"
+#     installPathPrefix = "/bin/"
+#     out_bom = Add().execute(test_sbom, installpath=(containerPathPrefix, installPathPrefix))
+#     for sw in out_bom.software:
+#         if containerPathPrefix in sw.containerPath:
+#             assert installPathPrefix in sw.installPath

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -8,7 +8,7 @@ import pathlib
 import pytest
 
 from surfactant.cmd.cli import cli_add, cli_find
-from surfactant.cmd.cli_commands import Cli
+from surfactant.cmd.cli_commands import Load, Save, Cli
 from surfactant.sbomtypes import SBOM, Relationship
 
 

--- a/tests/cmd/test_cli.py
+++ b/tests/cmd/test_cli.py
@@ -8,7 +8,7 @@ import pathlib
 import pytest
 
 from surfactant.cmd.cli import cli_add, cli_find
-from surfactant.cmd.cli_commands import Load, Save, Cli
+from surfactant.cmd.cli_commands import Cli
 from surfactant.sbomtypes import SBOM, Relationship
 
 


### PR DESCRIPTION
### Summary
This MR migrates the rest of the cli to the new non-interactive surfactant cli with added commands for ease of use. 

If merged this pull request will
- migrated `surfactant cli find` command
- migrated `surfactant cli add` command
- added `surfactant cli unload` command
- added `surfactant cli merge` command

### Proposed changes
The changes here will finish migrating the existing cli interface to the new structure. Proposed workflow is below:
```
surfactant cli load sbom.json # Loads the sbom into surfactant, surfactantn saves it in ~/.surfactant in a serialized form
surfactant cli find --containerPath=^123* # Loads from serialized form and finds subset that matches args
surfactant cli add --installPath 123/ /bin/ # Adds new install path based on containerpath
surfactant cli merge # merges changes to the subset from find back into the main sbom
surfactant cli find --uuid 123 # Find one entry to edit based on uuid
surfactant cli edit --components="IsAGRAF" # Editing an array by picking the element, this one edits a specific component in this entry
Current Value: {"name": "IsAGRAF", "Vendor": "Rockwell Collins Automation"}
New Value: {"name": "IsAGRAF", "Vendor": ["Rockwell Collins Automation"], "version": "1.2.3"} 
surfactant cli edit --name # Edit a string value
Current Value: oldname.out
New Value: 1.2.3.CPO.out
surfactant cli merge # Merge changes back into the rest of the SBOM
surfactant cli save new_sbom.json # save edited sbom to a new file
```