### PR TITLE
docs: Add core.include_all_files to list of settings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,6 +10,8 @@ See the [this page](configuration_files.md#settings-configuration-file) for deta
     - SBOM output format, see `--list-output-formats` for list of options; default is CyTRICS.
 - recorded_institution
     - Name of user's institution.
+- include_all_files
+    - Include all files in the SBOM, not just those with file types recognized by Surfactant; default is false.
 
 ## docker
 


### PR DESCRIPTION
Adds `core.include_all_files` to the list of configuration settings for Surfactant.

Resolves #343