### PR TITLE
fix: Specimen config includeAllFiles option being ignored

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -50,7 +50,7 @@ A specimen configuration file contains the information about the sample to gathe
 - **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file. Note that even on Windows, Unix style `/` directory separators should be used in paths.
 - **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in `extractPaths` were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various `extractPaths`.
 - **installPrefix**: (optional) where the files in `extractPaths` would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc. Note that even on Windows, Unix style `/` directory separators should be used in the path. If not given then the `extractPaths` will be used as the install paths.
-- **includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those recognized by Surfactant.
+- **includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those with types recognized by Surfactant.
 - **includeFileExts**: (optional) A list of file extensions to include, even if not recognized by Surfactant.
 - **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `includeAllFiles` and `excludeFileExts` are set, the specified extensions in `excludeFileExts` will still be excluded.
 

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -466,6 +466,7 @@ def sbom(
                             if (
                                 ftype := pm.hook.identify_file_type(filepath=filepath)
                                 or include_all_files
+                                or entry.includeAllFiles
                                 or os.path.splitext(filepath)[1].lower()
                                 in [ext.lower() for ext in entry.includeFileExts]
                             ) and os.path.splitext(filepath)[1].lower() not in [


### PR DESCRIPTION
Resolves #342

Add missing condition to include a check for includeAllFiles option from specimen configuration files.