### PR TITLE
Rename include all files to omit unrecognized types

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ A configuration file for a sample contains the information about the sample to g
 - **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file. Note that even on Windows, Unix style `/` directory separators should be used in paths.
 - **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in `extractPaths` were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various `extractPaths`.
 - **installPrefix**: (optional) where the files in `extractPaths` would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc. Note that even on Windows, Unix style `/` directory separators should be used in the path. If not given then the `extractPaths` will be used as the install paths.
-- **includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those recognized by Surfactant.
+- **omitUnrecognizedTypes**: (optional) Omit files with unrecognized types from the generated SBOM.
 - **includeFileExts**: (optional) A list of file extensions to include, even if not recognized by Surfactant.
-- **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `includeAllFiles` and `excludeFileExts` are set, the specified extensions in `excludeFileExts` will still be excluded.
+- **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `omitUnrecognizedTypes` and `includeFileExts` are set, the specified extensions in `includeFileExts` will still be included.
 
 #### Create config command
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -23,7 +23,7 @@ $  surfactant generate [OPTIONS] SPECIMEN_CONFIG SBOM_OUTFILE [INPUT_SBOM]
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
 **--input_format**: (optional) specifies the format of the input SBOM if one is being used (default: cytrics) (given as full module name of a surfactant plugin implementing the `read_sbom` hook)\
 **--help**: (optional) show the help message and exit\
-**--include_all_files**: (optional) include all files in the SBOM, rather than just those recognized by Surfactant
+**--omit_unrecognized_types**: (optional) Omit files with unrecognized types from the generated SBOM
 
 
 

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -50,9 +50,9 @@ A specimen configuration file contains the information about the sample to gathe
 - **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the sample folders, cannot be a file. Note that even on Windows, Unix style `/` directory separators should be used in paths.
 - **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the folders in `extractPaths` were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various `extractPaths`.
 - **installPrefix**: (optional) where the files in `extractPaths` would be if installed correctly on an actual system i.e. "C:/", "C:/Program Files/", etc. Note that even on Windows, Unix style `/` directory separators should be used in the path. If not given then the `extractPaths` will be used as the install paths.
-- **includeAllFiles**: (optional) If present and set to true, include all files in the SBOM, rather than only those with types recognized by Surfactant.
+- **omitUnrecognizedTypes**: (optional) Omit files with unrecognized types from the generated SBOM.
 - **includeFileExts**: (optional) A list of file extensions to include, even if not recognized by Surfactant.
-- **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `includeAllFiles` and `excludeFileExts` are set, the specified extensions in `excludeFileExts` will still be excluded.
+- **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `omitUnrecognizedTypes` and `includeFileExts` are set, the specified extensions in `includeFileExts` will still be included.
 
 ## Example configuration files
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ See the [this page](configuration_files.md#settings-configuration-file) for deta
 - recorded_institution
     - Name of user's institution.
 - include_all_files
-    - Include all files in the SBOM, not just those with file types recognized by Surfactant; default is false.
+    - Include all files in the SBOM (default). Set to `false` to only include files with types recognized by Surfactant; default is `true`.
 
 ## docker
 

--- a/surfactant/config.py
+++ b/surfactant/config.py
@@ -11,6 +11,6 @@ class ContextEntry:
     extractPaths: List[str]
     archive: Optional[str] = None
     installPrefix: Optional[str] = None
-    includeAllFiles: Optional[bool] = None
+    omitUnrecognizedTypes: Optional[bool] = None
     includeFileExts: Optional[List[str]] = None
     excludeFileExts: Optional[List[str]] = None

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -37,7 +37,7 @@ def extract_file_info(
     filetype: str,
     context: "Queue[ContextEntry]",
     children: List[Software],
-    include_all_files: bool,
+    omit_unrecognized_types: bool,
 ) -> object:
     """Extracts information from the given file to add to the given software entry. Return an
     object to be included as part of the metadata field, and potentially used as part of
@@ -51,7 +51,7 @@ def extract_file_info(
         filetype (str): File type information based on magic bytes.
         context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should still work without adding this parameter.
         children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add additional entries, though if the plugin extracts files to a temporary directory, the context argument should be used to have Surfactant process the files instead.
-        include_all_files (bool): If all files should be included in the SBOM, rather than only those with types that are recognized by Surfactant. When a plugin is adding additional context entries to the queue, it should typically default to propagating this value to the new context entries that it creates.
+        omit_unrecognized_types (bool): Whether files with types that are not recognized by Surfactant should be left out of the SBOM. When a plugin is adding additional context entries to the queue, it should typically default to propagating this value to the new context entries that it creates.
 
     Returns:
         object: An object to be added to the metadata field for the software entry. May be `None` to add no metadata.


### PR DESCRIPTION
Changes the default Surfactant behavior to include all files by default. This required changing defaults for both the specimen config file entry and the command line argument fallback to true, and the logic from `or` to `and` so that if the user sets either option to false, the file will be excluded. This change was needed for the config file `includeAllFiles` option to work, if `or` was used the default value of the command line option being true would essentially override it.