### PR TITLE
add parens in ftype condition

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -464,7 +464,7 @@ def sbom(
                             if not entry.excludeFileExts:
                                 entry.excludeFileExts = []
                             if (
-                                ftype := pm.hook.identify_file_type(filepath=filepath)
+                                (ftype := pm.hook.identify_file_type(filepath=filepath))
                                 or (not (omit_unrecognized_types or entry.omitUnrecognizedTypes))
                                 or (
                                     os.path.splitext(filepath)[1].lower()


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will fix the ftype condition in `generate.py`. Currently, the "or" conditions are not evaluated when the `identify_file_type` returns a string. So ftype gets set to the string returned.  And when `identify_file_type` returns None, the "or" conditions get evaluated and thus ftype gets set to the result of the "or" conditions. 

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->

Currently, when a file like `args.h` gets processed by surfactant, its filetype gets set to True, but when a parens is added around `ftype := pm.hook.identify_file_type(filepath=filepath)` in `generate.py`, it returns None.

Without the parens, `args.h`'s filetype gets set to True (incorrect):

![without paren](https://github.com/user-attachments/assets/a6353652-33d8-485a-a9b4-644e1cf518a1)

With the parens, `args.h` gets set to None:

![with paren](https://github.com/user-attachments/assets/b2b1a4f6-0b85-4b6b-a4e1-eb49b22cdfe4)


