### PR TITLE
Add pytest ignore option for plugins directory in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ include = ["surfactant", "surfactant.*"]
 version_file = "surfactant/_version.py"
 
 [tool.pytest.ini_options]
-addopts = ["--import-mode=importlib"]
+addopts = ["--import-mode=importlib", "--ignore=plugins"]
 pythonpath = "."
 
 [tool.ruff]


### PR DESCRIPTION
### Summary

Ignore pytests for third party plugins.

### Proposed changes

Will ignore pytests for third party plugins.
