### PR TITLE
ci: set default workflow permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: read-all
+
 jobs:
   build:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
     tags:
       - v*
 
+permissions: read-all
+
 jobs:
   build-wheel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the code scanning alerts about workflow permissions not being set.