### PR TITLE
feat: support plugin hints for software entry fields

### DIFF
--- a/surfactant/infoextractors/uimage_file.py
+++ b/surfactant/infoextractors/uimage_file.py
@@ -8,6 +8,7 @@
 # https://github.com/u-boot/u-boot/blob/master/boot/image.c
 
 import struct
+from typing import List, Tuple
 
 from loguru import logger
 
@@ -222,10 +223,19 @@ def supports_file(filetype) -> bool:
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(
+    sbom: SBOM,
+    software: Software,
+    filename: str,
+    filetype: str,
+    software_field_hints: List[Tuple[str, object, int]],
+) -> object:
     if not supports_file(filetype):
         return None
     try:
-        return {"uimage_header": _parse_uimage_header(filename)}
+        uimage_header = _parse_uimage_header(filename)
+        if "name" in uimage_header:
+            software_field_hints.append(("name", uimage_header["name"], 40))
+        return {"uimage_header": uimage_header}
     except ValueError as e:
         return None

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 from queue import Queue
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from pluggy import HookspecMarker
 
@@ -37,6 +37,7 @@ def extract_file_info(
     filetype: str,
     context: "Queue[ContextEntry]",
     children: List[Software],
+    software_field_hints: List[Tuple[str, object, int]],
     omit_unrecognized_types: bool,
 ) -> object:
     """Extracts information from the given file to add to the given software entry. Return an
@@ -49,9 +50,18 @@ def extract_file_info(
         software (Software): The software entry the gathered information will be added to.
         filename (str): The full path to the file to extract information from.
         filetype (str): File type information based on magic bytes.
-        context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should still work without adding this parameter.
-        children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add additional entries, though if the plugin extracts files to a temporary directory, the context argument should be used to have Surfactant process the files instead.
-        omit_unrecognized_types (bool): Whether files with types that are not recognized by Surfactant should be left out of the SBOM. When a plugin is adding additional context entries to the queue, it should typically default to propagating this value to the new context entries that it creates.
+        context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should
+            still work without adding this parameter.
+        children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add
+            additional entries, though if the plugin extracts files to a temporary directory, the context argument
+            should be used to have Surfactant process the files instead.
+        software_field_hints (List[tuple[str, str]]): List of tuples containing the name of a software entry field,
+            a suggested value for it, and a confidence level. Plugins can use this information to suggest values for
+            software entry fields by adding entries to this list. The one with the highest confidence level for a
+            field will be selected.
+        omit_unrecognized_types (bool): Whether files with types that are not recognized by Surfactant should be
+            left out of the SBOM. When a plugin is adding additional context entries to the queue, it should typically
+            default to propagating this value to the new context entries that it creates.
 
     Returns:
         object: An object to be added to the metadata field for the software entry. May be `None` to add no metadata.

--- a/tests/file_types/test_uimage_files.py
+++ b/tests/file_types/test_uimage_files.py
@@ -37,7 +37,9 @@ def test_uimage_files():
         file_path = os.path.join(data_dir, file_name)
         file_type = identify_file_type(file_path)
         assert file_type == "UIMAGE"
-        file_info = extract_file_info(SBOM(), Software(), file_path, file_type)
+        sw_field_hints = []
+        file_info = extract_file_info(SBOM(), Software(), file_path, file_type, sw_field_hints)
+        assert sw_field_hints == [("name", "Test uImage", 40)]
         assert "uimage_header" in file_info
         uimage_header = file_info["uimage_header"]
         for key, expected_value in expected_values.items():
@@ -52,5 +54,6 @@ def test_bad_uimage_file():
     file_path = os.path.join(base_path, "..", "data", "uimage_files", "bad1.img")
     file_type = identify_file_type(file_path)
     assert file_type == "UIMAGE"
-    file_info = extract_file_info(SBOM(), Software(), file_path, file_type)
+    sw_field_hints = []
+    file_info = extract_file_info(SBOM(), Software(), file_path, file_type, sw_field_hints)
     assert file_info is None


### PR DESCRIPTION
Adds a new optional argument for extract_file_info hooks to use called software_field_hints. Plugins can append tuples to the list that provide a suggested value for various fields in the software entry (such as name, version, etc), and some slightly arbitrary measure of how confident they are in the accuracy of the information.

If the fields already have a value set, the existing value takes priority (e.g. a user provided a starting point SBOM or an earlier run already picked a value). Vendor is a special case where any newly detected vendors will just be appended to the list of vendors.

Resolves #8