### PR TITLE
add current_context variable to extract_file_info hook

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -30,6 +30,7 @@ def real_path_to_install_path(root_path: str, install_path: str, filepath: str) 
 
 def get_software_entry(
     context_queue,
+    current_context,
     pluginmanager,
     parent_sbom: SBOM,
     filepath,
@@ -64,7 +65,7 @@ def get_software_entry(
             filename=filepath,
             filetype=filetype,
             context_queue=context_queue,
-            current_context=None,
+            current_context=current_context,
             children=sw_children,
             software_field_hints=sw_field_hints,
             omit_unrecognized_types=omit_unrecognized_types,
@@ -306,7 +307,6 @@ def sbom(
         filename_symlinks: Dict[str, List[str]] = {}
         while not context_queue.empty():
             entry: ContextEntry = context_queue.get()
-            current_context = entry
             if entry.archive:
                 logger.info("Processing parent container " + str(entry.archive))
                 # TODO: if the parent archive has an info extractor that does unpacking interally, should the children be added to the SBOM?
@@ -314,6 +314,7 @@ def sbom(
                 # extractor plugins meant to unpack files could be okay when used on an "archive", but then extractPaths should be empty
                 parent_entry, _ = get_software_entry(
                     context_queue,
+                    entry,
                     pm,
                     new_sbom,
                     entry.archive,
@@ -373,6 +374,7 @@ def sbom(
                     try:
                         sw_parent, sw_children = get_software_entry(
                             context_queue,
+                            entry,
                             pm,
                             new_sbom,
                             filepath,
@@ -484,6 +486,7 @@ def sbom(
                                 try:
                                     sw_parent, sw_children = get_software_entry(
                                         context_queue,
+                                        entry,
                                         pm,
                                         new_sbom,
                                         filepath,

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -29,7 +29,7 @@ def real_path_to_install_path(root_path: str, install_path: str, filepath: str) 
 
 
 def get_software_entry(
-    context,
+    context_queue,
     pluginmanager,
     parent_sbom: SBOM,
     filepath,
@@ -63,7 +63,8 @@ def get_software_entry(
             software=sw_entry,
             filename=filepath,
             filetype=filetype,
-            context=context,
+            context_queue=context_queue,
+            current_context=None,
             children=sw_children,
             software_field_hints=sw_field_hints,
             omit_unrecognized_types=omit_unrecognized_types,
@@ -283,10 +284,10 @@ def sbom(
     output_writer = find_io_plugin(pm, output_format, "write_sbom")
     input_reader = find_io_plugin(pm, input_format, "read_sbom")
 
-    context: queue.Queue[ContextEntry] = queue.Queue()
+    context_queue: queue.Queue[ContextEntry] = queue.Queue()
 
     for cfg_entry in specimen_config:
-        context.put(ContextEntry(**cfg_entry))
+        context_queue.put(ContextEntry(**cfg_entry))
 
     # define the new_sbom variable type
     new_sbom: SBOM
@@ -303,15 +304,16 @@ def sbom(
         file_symlinks: Dict[str, List[str]] = {}
         # List of filename symlinks; keys are SHA256 hashes, values are file names
         filename_symlinks: Dict[str, List[str]] = {}
-        while not context.empty():
-            entry: ContextEntry = context.get()
+        while not context_queue.empty():
+            entry: ContextEntry = context_queue.get()
+            current_context = entry
             if entry.archive:
                 logger.info("Processing parent container " + str(entry.archive))
                 # TODO: if the parent archive has an info extractor that does unpacking interally, should the children be added to the SBOM?
                 # current thoughts are (Syft) doesn't provide hash information for a proper SBOM software entry, so exclude these
                 # extractor plugins meant to unpack files could be okay when used on an "archive", but then extractPaths should be empty
                 parent_entry, _ = get_software_entry(
-                    context,
+                    context_queue,
                     pm,
                     new_sbom,
                     entry.archive,
@@ -370,7 +372,7 @@ def sbom(
                     # breakpoint()
                     try:
                         sw_parent, sw_children = get_software_entry(
-                            context,
+                            context_queue,
                             pm,
                             new_sbom,
                             filepath,
@@ -481,7 +483,7 @@ def sbom(
                             ]:
                                 try:
                                     sw_parent, sw_children = get_software_entry(
-                                        context,
+                                        context_queue,
                                         pm,
                                         new_sbom,
                                         filepath,

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -35,9 +35,15 @@ def supports_file(filetype: str) -> str:
     return None
 
 
+# pylint: disable=too-many-positional-arguments
 @surfactant.plugin.hookimpl
 def extract_file_info(
-    sbom: SBOM, software: Software, filename: str, filetype: str, context: "Queue[ContextEntry]"
+    sbom: SBOM,
+    software: Software,
+    filename: str,
+    filetype: str,
+    context_queue: "Queue[ContextEntry]",
+    current_context: Optional[ContextEntry],
 ) -> Optional[Dict[str, Any]]:
     # Check if the file is compressed and get its format
     compression_format = supports_file(filetype)
@@ -52,8 +58,8 @@ def extract_file_info(
         archive=filename, installPrefix="", extractPaths=[temp_folder], skipProcessingArchive=True
     )
 
-    # Add new ContextEntry to queue
-    context.put(new_entry)
+    # Add new ContextEntry object to queue
+    context_queue.put(new_entry)
     logger.info(f"New ContextEntry added for extracted files: {temp_folder}")
 
     return None

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -35,7 +35,8 @@ def extract_file_info(
     software: Software,
     filename: str,
     filetype: str,
-    context: "Queue[ContextEntry]",
+    context_queue: "Queue[ContextEntry]",
+    current_context: Optional[ContextEntry],
     children: List[Software],
     software_field_hints: List[Tuple[str, object, int]],
     omit_unrecognized_types: bool,
@@ -50,8 +51,9 @@ def extract_file_info(
         software (Software): The software entry the gathered information will be added to.
         filename (str): The full path to the file to extract information from.
         filetype (str): File type information based on magic bytes.
-        context (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should
+        context_queue (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should
             still work without adding this parameter.
+        current_context (Optional[ContextEntry]): A single ContextEntry object in the context queue.
         children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add
             additional entries, though if the plugin extracts files to a temporary directory, the context argument
             should be used to have Surfactant process the files instead.

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -51,9 +51,12 @@ def extract_file_info(
         software (Software): The software entry the gathered information will be added to.
         filename (str): The full path to the file to extract information from.
         filetype (str): File type information based on magic bytes.
-        context_queue (Queue[ContextEntry]): Modifiable queue of entries from input config file. Existing plugins should
-            still work without adding this parameter.
-        current_context (Optional[ContextEntry]): A single ContextEntry object in the context queue.
+        context_queue (Queue[ContextEntry]): Modifiable queue of entries typically initialized from the input specimen
+            config file. Plugins can add new entries to the queue to make Surfactant process additional files/folders.
+            Existing plugins should still work without adding this parameter.
+        current_context (Optional[ContextEntry]): The ContextEntry object from the queue whose files are currently being
+            processed (modifying it is considered undefined behavior and should be avoided). Most plugins do not need to
+            use this parameter.
         children (List[Software]): List of additional software entries to include in the SBOM. Plugins can add
             additional entries, though if the plugin extracts files to a temporary directory, the context argument
             should be used to have Surfactant process the files instead.


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will add an additional optional parameter called `current_context`. Plugins can now access the current entry in the queue. 


### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Currently, we have the `context` parameter, which references the context queue. This `context` param has been renamed to `context_queue` to make it more clear what it is. 
