### PR TITLE
add context entry for archives

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -53,7 +53,7 @@ A specimen configuration file contains the information about the sample to gathe
 - **omitUnrecognizedTypes**: (optional) If set to True, files with unrecognized types will be omitted from the generated SBOM.
 - **includeFileExts**: (optional) A list of file extensions to include, even if not recognized by Surfactant. `omitUnrecognizedTypes` must be set to True for this to take effect.
 - **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `omitUnrecognizedTypes` and `includeFileExts` are set, the specified extensions in `includeFileExts` will still be included.
-- **skipProcessingArchive**: (optional) Skip processing the given archive file with info extractors. Software entry for the archive file will only contain basic information such as hashes. Default setting is False.
+- **skipProcessingArchive**: (optional) Skip processing the given archive file with info extractors. Software entry for the archive file will still appear in the SBOM with basic info such as hashes, but no information extraction plugins will run to pull out extra file type specific info. Default setting is False.
 
 ## Example configuration files
 

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -285,10 +285,10 @@ def sbom(
     output_writer = find_io_plugin(pm, output_format, "write_sbom")
     input_reader = find_io_plugin(pm, input_format, "read_sbom")
 
-    context_queue: queue.Queue[ContextEntry] = queue.Queue()
+    contextQ: queue.Queue[ContextEntry] = queue.Queue()
 
     for cfg_entry in specimen_config:
-        context_queue.put(ContextEntry(**cfg_entry))
+        contextQ.put(ContextEntry(**cfg_entry))
 
     # define the new_sbom variable type
     new_sbom: SBOM
@@ -305,15 +305,15 @@ def sbom(
         file_symlinks: Dict[str, List[str]] = {}
         # List of filename symlinks; keys are SHA256 hashes, values are file names
         filename_symlinks: Dict[str, List[str]] = {}
-        while not context_queue.empty():
-            entry: ContextEntry = context_queue.get()
+        while not contextQ.empty():
+            entry: ContextEntry = contextQ.get()
             if entry.archive:
                 logger.info("Processing parent container " + str(entry.archive))
                 # TODO: if the parent archive has an info extractor that does unpacking interally, should the children be added to the SBOM?
                 # current thoughts are (Syft) doesn't provide hash information for a proper SBOM software entry, so exclude these
                 # extractor plugins meant to unpack files could be okay when used on an "archive", but then extractPaths should be empty
                 parent_entry, _ = get_software_entry(
-                    context_queue,
+                    contextQ,
                     entry,
                     pm,
                     new_sbom,
@@ -373,7 +373,7 @@ def sbom(
                     # breakpoint()
                     try:
                         sw_parent, sw_children = get_software_entry(
-                            context_queue,
+                            contextQ,
                             entry,
                             pm,
                             new_sbom,
@@ -485,7 +485,7 @@ def sbom(
                             ]:
                                 try:
                                     sw_parent, sw_children = get_software_entry(
-                                        context_queue,
+                                        contextQ,
                                         entry,
                                         pm,
                                         new_sbom,

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -56,30 +56,28 @@ def extract_file_info(
 
     # Check that archive key exists and filename is same as archive file
     if current_context.archive and current_context.archive == filename:
-        # If archive has empty list of extractPaths, an entry to the queue will be added
-        if current_context.extractPaths == []:
-            temp_folder = check_compression_type(current_context.archive, compression_format)
-            install_prefix = current_context.installPrefix
-            extract_paths = [temp_folder]
-            logger.info(f"New ContextEntry added for archive: {current_context.archive}")
-        # Assume archive is already extracted if the extractPaths is not empty
-        else:
+        if current_context.extractPaths is not None and current_context.extractPaths != []:
             logger.info(
                 f"Already extracted, skipping extraction for archive: {current_context.archive}"
             )
             return None
-    # Assume there is a compressed file in the extractPaths
-    elif current_context.installPrefix == "/":
-        # Decompress the file based on its format
-        temp_folder = check_compression_type(filename, compression_format)
-        extract_paths = [temp_folder]
-        logger.info(f"New ContextEntry added for extracted files: {temp_folder}")
+
+        # Inherit the context entry install prefix for the extracted files
+        install_prefix = current_context.installPrefix
+
+    # Decompress the file based on its format
+    temp_folder = check_compression_type(filename, compression_format)
+    extract_paths = [temp_folder]
 
     # Create a new context entry and add it to the queue
     new_entry = ContextEntry(
-        archive=filename, installPrefix="", extractPaths=extract_paths, skipProcessingArchive=True
+        archive=filename,
+        installPrefix=install_prefix,
+        extractPaths=extract_paths,
+        skipProcessingArchive=True,
     )
     context_queue.put(new_entry)
+    logger.info(f"New ContextEntry added for extracted files: {temp_folder}")
 
     return None
 

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -46,8 +46,22 @@ def extract_file_info(
     current_context: Optional[ContextEntry],
 ) -> Optional[Dict[str, Any]]:
     # Check if the file is compressed and get its format
+
     compression_format = supports_file(filetype)
     if not compression_format:
+        return None
+
+    # If archive key exists, but has empty list of extractPaths, add an entry to the queue for the archive
+    if current_context.archive and current_context.extractPaths == []:
+        temp_folder_archive = check_compression_type(current_context.archive, compression_format)
+        archive_entry = ContextEntry(
+            archive=current_context.archive,
+            installPrefix=current_context.installPrefix,  # inherit install prefix from current context
+            extractPaths=[temp_folder_archive],
+            skipProcessingArchive=True,
+        )
+        context_queue.put(archive_entry)
+        logger.info(f"New ContextEntry added for archive: {current_context.archive}")
         return None
 
     # Decompress the file based on its format


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will allow archives listed in the config file to be extracted. This depends on issue https://github.com/LLNL/Surfactant/issues/365 to be resolved. 365 will make sure that the archive file has an appropriate `filetype`.

Here is a sample config file:

![Screenshot 2025-03-30 at 11 24 29 PM](https://github.com/user-attachments/assets/fba0f57b-b259-459c-9647-1ac25b1742c1)

Using the sample config file above, if we have an `archive` key and an empty list of `extractPaths`, no extraction occurs. With this PR, we can add a context entry to the queue for the archive and have the context entry added to the queue inherit the install prefix from the current context. Linked to issue https://github.com/LLNL/Surfactant/issues/366


### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Add a new context entry if the current context has an archive but empty list of extract paths.
