### PR TITLE
add filetype identification to archive files

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -318,6 +318,7 @@ def sbom(
                     pm,
                     new_sbom,
                     entry.archive,
+                    filetype=pm.hook.identify_file_type(filepath=entry.archive),
                     user_institution_name=recorded_institution,
                     skip_extraction=entry.skipProcessingArchive,
                 )


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will allow filetype identification for archive files. Addresses https://github.com/LLNL/Surfactant/issues/365

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Run identify_file_type hook on the `entry.archive` file and call `get_software_entry()` with the `filetype` parameter.

ex. `filetype=pm.hook.identify_file_type(filepath=entry.archive)`
