### PR TITLE
fix: vendor field being set to a list of list of strings (vendors)

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -114,7 +114,7 @@ def get_software_entry(
             # add any new vendors detected to the list
             for vendor in value:
                 if vendor not in sw_entry.vendor:
-                    sw_entry.vendor.append(value)
+                    sw_entry.vendor.append(vendor)
         elif field == "description" and not sw_entry.description:
             sw_entry.description = value
         elif field == "comments" and not sw_entry.comments:


### PR DESCRIPTION
Fixes a bug that was iterating over each individual vendor, but then appending the entire value list, not the single vendor. The bug was creating a list of lists in the vendor field. See: https://github.com/LLNL/Surfactant/issues/396.

Testing:
The output was tested against the schema.
