### PR TITLE
Gzip garbage bytes

### DIFF
--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -69,15 +69,16 @@ def extract_file_info(
     temp_folder = check_compression_type(filename, compression_format)
     extract_paths = [temp_folder]
 
-    # Create a new context entry and add it to the queue
-    new_entry = ContextEntry(
-        archive=filename,
-        installPrefix=install_prefix,
-        extractPaths=extract_paths,
-        skipProcessingArchive=True,
-    )
-    context_queue.put(new_entry)
-    logger.info(f"New ContextEntry added for extracted files: {temp_folder}")
+    if temp_folder is not None:
+        # Create a new context entry and add it to the queue
+        new_entry = ContextEntry(
+            archive=filename,
+            installPrefix=install_prefix,
+            extractPaths=extract_paths,
+            skipProcessingArchive=True,
+        )
+        context_queue.put(new_entry)
+        logger.info(f"New ContextEntry added for extracted files: {temp_folder}")
 
     return None
 
@@ -153,8 +154,15 @@ def decompress_file(filename, compression_type):
             with lzma.open(filename, "rb") as f_in:
                 with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-    except (gzip.BadGzipFile, OSError) as e:
-        print(f"Warning: Trailing garbage bytes or concatenated streams ignored {filename}: {e}")
+    except gzip.BadGzipFile as e:
+        # Likely only the first stream of a concatenated file was decompressed, so we will still keep the temp dir
+        logger.warning(
+            f"Trailing garbage bytes or concatenated streams ignored for {filename}: {e}"
+        )
+    except OSError as e:
+        logger.warning(f"Unable to decompress {filename}: {e}")
+        # Return None since this file will be completely unusable.
+        return None
 
     return temp_folder
 

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -153,7 +153,7 @@ def decompress_file(filename, compression_type):
             with lzma.open(filename, "rb") as f_in:
                 with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-    except gzip.BadGzipFile as e:
+    except (gzip.BadGzipFile, OSError) as e:
         print(f"Warning: Trailing garbage bytes or concatenated streams ignored {filename}: {e}")
 
     return temp_folder

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -140,18 +140,21 @@ def decompress_file(filename, compression_type):
     elif compression_type == "XZ" and filename.endswith(".xz"):
         output_filename = pathlib.Path(filename).stem
 
-    if compression_type == "GZIP":
-        with gzip.open(filename, "rb") as f_in:
-            with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
-    elif compression_type == "BZIP2":
-        with bz2.open(filename, "rb") as f_in:
-            with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
-    elif compression_type == "XZ":
-        with lzma.open(filename, "rb") as f_in:
-            with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
-                shutil.copyfileobj(f_in, f_out)
+    try:
+        if compression_type == "GZIP":
+            with gzip.open(filename, "rb") as f_in:
+                with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+        elif compression_type == "BZIP2":
+            with bz2.open(filename, "rb") as f_in:
+                with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+        elif compression_type == "XZ":
+            with lzma.open(filename, "rb") as f_in:
+                with open(os.path.join(temp_folder, output_filename), "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+    except gzip.BadGzipFile as e:
+        print(f"Warning: Trailing garbage bytes or concatenated streams ignored {filename}: {e}")
 
     return temp_folder
 


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will stop surfactant from crashing if it encounters a GZIP file with trailing garbage bytes. 

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Added `gzip.BadGzipFile` and `OSError` exceptions. `gzip.BadGzipFile` specifically works with GZIP files and `OSError` is caught when the program comes across corrupted BZIP2 and XZ files. 
