### PR TITLE
Fix crash when ID'ing small files

### DIFF
--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 import json
+import os
 import pathlib
 import tarfile
 from enum import Enum, auto
@@ -237,11 +238,12 @@ def identify_file_type(filepath: str) -> Optional[str]:
 
             # MacOS dmg:
             # https://en.wikipedia.org/wiki/List_of_file_signatures
-            f.seek(-512, 2)
-            macos_bytes = f.read(4)
-            if macos_bytes[0:4] == b"koly":
-                return "MACOS_DMG"
-            f.seek(0)
+            file_size = f.seek(0, os.SEEK_END)
+            if file_size >= 512:
+                f.seek(-512, os.SEEK_END)
+                macos_bytes = f.read(4)
+                if macos_bytes[0:4] == b"koly":
+                    return "MACOS_DMG"
 
             return None
     except FileNotFoundError:


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

Surfactant crashes when parsing files that are smaller than 512 bytes due to an out-of-bounds `seek()` in the macOS DMG magic check

### Proposed changes

Check the size of the file before running the check & replace magic number with labeled constant
