### PR TITLE
fix: bump minimum requires-python to 3.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 description = "Modular framework to gather file information, analyze dependencies, and generate an SBOM"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8.1"
 keywords = ["sbom", "pe", "elf", "ole", "msi"]
 license = {text = "MIT License"}
 classifiers = [


### PR DESCRIPTION
The minimum requires-python needs to be bumped to 3.8.1 to match textual. uv identified this issue with the lower bound of our supported version. Issue should also go away once we update our minimum required python version to 3.9