### PR TITLE
chore: update pyproject.toml to install pymsi from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "olefile==0.47.*",
     "defusedxml==0.7.*",
     "spdx-tools==0.8.*",
+    # Pinned to specific version for potential breaking changes
     "cyclonedx-python-lib==9.1.0",
     "pluggy==1.*",
     "click==8.*",
@@ -58,8 +59,8 @@ dependencies = [
     "textual==3.*",
     "requests>=2.32.3",
     "rarfile==4.2.*",
-    # TODO: add version info once uploaded to PyPI
-    "msi@git+https://github.com/nightlark/pymsi.git@asriel",
+    # Pinned to specific version for potential breaking changes
+    "python-msi==0.0.0a0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Install pymsi from the package that is on PyPI.