### PR TITLE
Change filetype variable from str to list[str] for polyglot detection

### DIFF
--- a/plugins/angrimportfinder/surfactantplugin_angrimportfinder.py
+++ b/plugins/angrimportfinder/surfactantplugin_angrimportfinder.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 import json
 from pathlib import Path
+from typing import List
 
 import angr
 from cle import CLECompatibilityError
@@ -16,17 +17,17 @@ from surfactant.sbomtypes import SBOM, Software
 @surfactant.plugin.hookimpl(specname="extract_file_info")
 # extract_strings(sbom: SBOM, software: Software, filename: str, filetype: str):
 # def angrimport_finder(filename: str, filetype: str, filehash: str):
-def angrimport_finder(sbom: SBOM, software: Software, filename: str, filetype: str):
+def angrimport_finder(sbom: SBOM, software: Software, filename: str, filetype: List[str]):
     """
     :param sbom(SBOM): The SBOM that the software entry/file is being added to. Can be used to add observations or analysis data.
     :param software(Software): The software entry associated with the file to extract information from.
     :param filename (str): The full path to the file to extract information from.
-    :param filetype (str): File type information based on magic bytes.
+    :param filetype (List[str]): File type information based on magic bytes.
     """
 
     # Only parsing executable files
-    if filetype not in ["ELF", "PE"]:
-        pass
+    if not ("ELF" in filetype or "PE" in filetype):
+        return
     filehash = str(software.sha256)
     filename = Path(filename)
     flist = []

--- a/plugins/binary2strings/surfactantplugin_binary2strings.py
+++ b/plugins/binary2strings/surfactantplugin_binary2strings.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 import json
 from pathlib import Path
+from typing import List
 
 import binary2strings as b2s
 from loguru import logger
@@ -13,19 +14,19 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 @surfactant.plugin.hookimpl(specname="extract_file_info")
-def extract_strings(sbom: SBOM, software: Software, filename: str, filetype: str):
+def extract_strings(sbom: SBOM, software: Software, filename: str, filetype: List[str]):
     """
     Extract ASCII strings from a binary file using binary2strings.
     :param sbom(SBOM): The SBOM that the software entry/file is being added to. Can be used to add observations or analysis data.
     :param software(Software): The software entry associated with the file to extract information from.
     :param filename (str): The full path to the file to extract information from.
-    :param filetype (str): File type information based on magic bytes.
+    :param filetype (List[str]): File type information based on magic bytes.
     """
     shaHash = str(software.sha256)
     min_len = 4
     # Only parsing executable files
-    if filetype not in ["ELF", "PE"]:
-        pass
+    if not ("ELF" in filetype or "PE" in filetype):
+        return
 
     filename = Path(filename)
     flist = []

--- a/plugins/checksec.py/surfactantplugin_checksec.py
+++ b/plugins/checksec.py/surfactantplugin_checksec.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 from pathlib import Path
+from typing import List
 
 from checksec.__main__ import checksec_file
 from checksec.elf import ELFChecksecData
@@ -13,8 +14,8 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
-    if filetype not in ["ELF", "PE"]:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
+    if not ("ELF" in filetype or "PE" in filetype):
         return None
     checksec_data = checksec_file(Path(filename))
     data = {}

--- a/plugins/cvebin2vex/surfactantplugin_cvebintool2vex.py
+++ b/plugins/cvebin2vex/surfactantplugin_cvebintool2vex.py
@@ -4,6 +4,7 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import List
 
 from loguru import logger
 
@@ -139,16 +140,16 @@ def delete_extra_files(*file_paths):
 
 
 @surfactant.plugin.hookimpl(specname="extract_file_info")
-def cvebintool2vex(sbom: SBOM, software: Software, filename: str, filetype: str):
+def cvebintool2vex(sbom: SBOM, software: Software, filename: str, filetype: List[str]):
     """
     :param sbom(SBOM): The SBOM that the software entry/file is being added to. Can be used to add observations or analysis data.
     :param software(Software): The software entry associated with the file to extract information from.
     :param filename (str): The full path to the file to extract information from.
-    :param filetype (str): File type information based on magic bytes.
+    :param filetype (List[str]): File type information based on magic bytes.
     """
     # Only parsing executable files
-    if filetype not in ["ELF", "PE"]:
-        pass
+    if not ("ELF" in filetype or "PE" in filetype):
+        return
 
     shaHash = str(software.sha256)
     filename = Path(filename)

--- a/plugins/fuzzyhashes/surfactantplugin_fuzzyhashes.py
+++ b/plugins/fuzzyhashes/surfactantplugin_fuzzyhashes.py
@@ -6,6 +6,7 @@
 
 import logging
 from pathlib import Path
+from typing import List
 
 try:
     import ssdeep
@@ -29,13 +30,13 @@ def do_ssdeep(bin_data: bytes):
 
 
 @surfactant.plugin.hookimpl(specname="extract_file_info")
-def fuzzyhashes(sbom: SBOM, software: Software, filename: str, filetype: str):
+def fuzzyhashes(sbom: SBOM, software: Software, filename: str, filetype: List[str]):
     """
     Generate TLSH and potentially SSDEEP fuzzy hashes for the provided files.
     :param sbom(SBOM): The SBOM that the software entry/file is being added to. Can be used to add observations or analysis data.
     :param software(Software): The software entry associated with the file to extract information from.
     :param filename (str): The full path to the file to extract information from.
-    :param filetype (str): File type information based on magic bytes.
+    :param filetype (List[str]): File type information based on magic bytes.
     """
 
     hashdata = [(do_tlsh, "tlsh")]

--- a/plugins/grype/surfactantplugin_grype.py
+++ b/plugins/grype/surfactantplugin_grype.py
@@ -76,16 +76,16 @@ def run_grype(filename: str) -> object:
 
 @surfactant.plugin.hookimpl
 def extract_file_info(
-    sbom: SBOM, software: Software, filename: str, filetype: str, children: list
+    sbom: SBOM, software: Software, filename: str, filetype: List[str], children: list
 ) -> Optional[List[Software]]:
     if disable_plugin:
         return None
 
-    if filetype not in ("DOCKER_TAR", "DOCKER_GZIP"):
+    if not ("DOCKER_TAR" in filetype or "DOCKER_GZIP" in filetype):
         return None
 
     try:
-        if filetype == "DOCKER_GZIP":
+        if "DOCKER_GZIP" in filetype:
             logger.debug(f"Decompressing gzip file: {filename}")
             with open(filename, "rb") as gzip_in:
                 gzip_data = gzip_in.read()

--- a/plugins/syft/surfactantplugin_syft.py
+++ b/plugins/syft/surfactantplugin_syft.py
@@ -10,11 +10,11 @@ from surfactant.sbomtypes import SBOM, Relationship, Software
 
 @surfactant.plugin.hookimpl
 def extract_file_info(
-    sbom: SBOM, software: Software, filename: str, filetype: str, children: list
+    sbom: SBOM, software: Software, filename: str, filetype: List[str], children: list
 ) -> Optional[List[Software]]:
     pm = get_plugin_manager()
     # Change to properly filter filetypes, add to if statement for filetypes syft should run for
-    if filetype == "TAR":
+    if "TAR" in filetype:
         data = subprocess.check_output(
             "anchore_syft " + filename + " -o json --scope all-layers", shell=True
         )

--- a/surfactant/fileinfo.py
+++ b/surfactant/fileinfo.py
@@ -7,6 +7,8 @@ import stat
 import sys
 from hashlib import md5, sha1, sha256
 
+from loguru import logger
+
 
 def get_file_info(filename):
     """Get information about a file.
@@ -90,11 +92,15 @@ def sha256sum(filename):
     Raises:
         FileNotFoundError: If the given filename could not be found.
     """
-    h = sha256()
-    with open(filename, "rb") as f:
-        # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
-        chunk = f.read(h.block_size)
-        while chunk:
-            h.update(chunk)
+    if os.path.isfile(filename):
+        h = sha256()
+        with open(filename, "rb") as f:
+            print("filenamae: ", filename)
+            # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
             chunk = f.read(h.block_size)
-    return h.hexdigest()
+            while chunk:
+                h.update(chunk)
+                chunk = f.read(h.block_size)
+        return h.hexdigest()
+    logger.warning(f"Skipping non-file: {filename}")
+    return None

--- a/surfactant/fileinfo.py
+++ b/surfactant/fileinfo.py
@@ -7,8 +7,6 @@ import stat
 import sys
 from hashlib import md5, sha1, sha256
 
-from loguru import logger
-
 
 def get_file_info(filename):
     """Get information about a file.
@@ -92,14 +90,11 @@ def sha256sum(filename):
     Raises:
         FileNotFoundError: If the given filename could not be found.
     """
-    if os.path.isfile(filename):
-        h = sha256()
-        with open(filename, "rb") as f:
-            # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
+    h = sha256()
+    with open(filename, "rb") as f:
+        # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
+        chunk = f.read(h.block_size)
+        while chunk:
+            h.update(chunk)
             chunk = f.read(h.block_size)
-            while chunk:
-                h.update(chunk)
-                chunk = f.read(h.block_size)
-        return h.hexdigest()
-    logger.warning(f"Skipping non-file: {filename}")
-    return None
+    return h.hexdigest()

--- a/surfactant/fileinfo.py
+++ b/surfactant/fileinfo.py
@@ -95,7 +95,6 @@ def sha256sum(filename):
     if os.path.isfile(filename):
         h = sha256()
         with open(filename, "rb") as f:
-            print("filenamae: ", filename)
             # Reading is buffered by default (https://docs.python.org/3/library/functions.html#open)
             chunk = f.read(h.block_size)
             while chunk:

--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -4,15 +4,18 @@
 # SPDX-License-Identifier: MIT
 import pathlib
 import re
-from typing import List, Optional
+from typing import Optional
 
 from loguru import logger
 
 import surfactant.plugin
 
+print("hello JS")
+
 
 @surfactant.plugin.hookimpl
-def identify_file_type(filepath: str) -> Optional[List[str]]:
+def identify_file_type(filepath: str) -> Optional[str]:
+    print("inside JS")
     # pylint: disable=too-many-return-statements
     _filetype_extensions = {
         ".sh": "SHELL",
@@ -38,26 +41,25 @@ def identify_file_type(filepath: str) -> Optional[List[str]]:
         b"python3": "PYTHON",
         b"perl": "PERL",
     }
-    filetype_matches = []
     try:
+        print("hello")
         with open(filepath, "rb") as f:
             head = f.read(256)
             if head.startswith(b"<!DOCTYPE html>"):
-                filetype_matches.append("HTML")
+                return ["HTML"]
             if head.startswith(b"#!") and b"\n" in head:
                 end_line = head.index(b"\n")
                 head = head[:end_line]
                 for interpreter, filetype in _interpreters.items():
                     if re.search(interpreter, head):
-                        filetype_matches.extend(filetype)
-                        # return filetype
-                filetype_matches.append("SHEBANG")
+                        return [filetype]
+                return ["SHEBANG"]
     except FileNotFoundError:
         logger.warning(f"File not found: {filepath}")
         return None
     suffix = pathlib.Path(filepath).suffix.lower()
     if suffix in _filetype_extensions:
-        filetype_matches.append(_filetype_extensions[suffix])
-    if filetype_matches:
-        return filetype_matches
+        print("suffix: ", suffix)
+        print("filetype: ", [_filetype_extensions[suffix]])
+        return [_filetype_extensions[suffix]]
     return None

--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -10,12 +10,9 @@ from loguru import logger
 
 import surfactant.plugin
 
-print("hello JS")
-
 
 @surfactant.plugin.hookimpl
 def identify_file_type(filepath: str) -> Optional[str]:
-    print("inside JS")
     # pylint: disable=too-many-return-statements
     _filetype_extensions = {
         ".sh": "SHELL",
@@ -42,7 +39,6 @@ def identify_file_type(filepath: str) -> Optional[str]:
         b"perl": "PERL",
     }
     try:
-        print("hello")
         with open(filepath, "rb") as f:
             head = f.read(256)
             if head.startswith(b"<!DOCTYPE html>"):
@@ -59,7 +55,5 @@ def identify_file_type(filepath: str) -> Optional[str]:
         return None
     suffix = pathlib.Path(filepath).suffix.lower()
     if suffix in _filetype_extensions:
-        print("suffix: ", suffix)
-        print("filetype: ", [_filetype_extensions[suffix]])
         return [_filetype_extensions[suffix]]
     return None

--- a/surfactant/filetypeid/id_extension.py
+++ b/surfactant/filetypeid/id_extension.py
@@ -49,7 +49,8 @@ def identify_file_type(filepath: str) -> Optional[List[str]]:
                 head = head[:end_line]
                 for interpreter, filetype in _interpreters.items():
                     if re.search(interpreter, head):
-                        return filetype
+                        filetype_matches.extend(filetype)
+                        # return filetype
                 filetype_matches.append("SHEBANG")
     except FileNotFoundError:
         logger.warning(f"File not found: {filepath}")

--- a/surfactant/filetypeid/id_hex.py
+++ b/surfactant/filetypeid/id_hex.py
@@ -87,9 +87,9 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 elif check_intel(curr):
                     percent_intel += 1
             if percent_intel > percent_motorola:
-                return "INTEL_HEX"
+                return ["INTEL_HEX"]
             if percent_motorola > percent_intel:
-                return "MOTOROLA_SREC"
+                return ["MOTOROLA_SREC"]
             return None
 
     except (FileNotFoundError, UnicodeDecodeError):

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -58,36 +58,26 @@ def identify_file_type(filepath: str) -> Optional[str]:
             if magic_bytes[:4] == b"\x7fELF":
                 filetype_matches.append("ELF")
             if magic_bytes[:2] == b"MZ":
-                # Several file types start with the same `MZ` signature, so we need to handle them.
-                # Regardless, the initial header (may) contain a pointer to an additional COFF
-                # header, so we look for that as the first step.
                 coff_addr = (
                     int.from_bytes(magic_bytes[0x3C:0x40], byteorder="little", signed=False)
                     & 0xFFFF
                 )
-
-                # Check to see if the coff_addr is still within the initial read; if not, we read up
-                # to where it is.
                 if coff_addr > len(magic_bytes):
                     magic_bytes += f.read(coff_addr + 4 - len(magic_bytes))
-
-                # If coff_addr is still longer than what has been read so far, it points off the end
-                # of the file, so the file is either malformed or something else is up.
                 if coff_addr + 4 > len(magic_bytes):
                     filetype_matches.append("Malformed PE")
-
-                if magic_bytes[coff_addr : coff_addr + 4] != b"PE\x00\x00":
+                elif magic_bytes[coff_addr : coff_addr + 4] != b"PE\x00\x00":
                     filetype_matches.append("DOS")
-
-                # Check for the linux kernel header at 0x202 (may require a second read)
-                if len(magic_bytes) < 0x206:
+                elif len(magic_bytes) < 0x206:
                     magic_bytes += f.read(265)
-
-                if magic_bytes[0x202:0x206] == b"HdrS":
+                    if magic_bytes[0x202:0x206] == b"HdrS":
+                        filetype_matches.append("Linux Kernel Image")
+                    else:
+                        filetype_matches.append("PE")
+                elif magic_bytes[0x202:0x206] == b"HdrS":
                     filetype_matches.append("Linux Kernel Image")
-
-                # Otherwise, call it a PE and be done with it.
-                filetype_matches.append("PE")
+                else:
+                    filetype_matches.append("PE")
 
             if magic_bytes[:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
                 # MSI (install), MSP (patch), MST (transform), and MSM (merge) files are all types of OLE files
@@ -103,7 +93,8 @@ def identify_file_type(filepath: str) -> Optional[str]:
             if magic_bytes[:2] == b"\x1f\x8b":
                 if is_docker_archive(filepath):
                     filetype_matches.append("DOCKER_GZIP")
-                filetype_matches.append("GZIP")
+                else:
+                    filetype_matches.append("GZIP")
             # Check for compressed TAR files (tar.bz2, tar.xz)
             if magic_bytes[:3] == b"BZh":
                 filetype_matches.append("BZIP2")
@@ -112,7 +103,8 @@ def identify_file_type(filepath: str) -> Optional[str]:
             if magic_bytes[257:265] == b"ustar\x0000" or magic_bytes[257:265] == b"ustar  \x00":
                 if is_docker_archive(filepath):
                     filetype_matches.append("DOCKER_TAR")
-                filetype_matches.append("TAR")
+                else:
+                    filetype_matches.append("TAR")
             if magic_bytes[:6] == b"\x52\x61\x72\x21\x1a\x07":
                 filetype_matches.append("RAR")
             if magic_bytes[:4] in [b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"]:

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -76,8 +76,9 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 elif magic_bytes[coff_addr : coff_addr + 4] != b"PE\x00\x00":
                     filetype_matches.append("DOS")
                 # Check for the linux kernel header at 0x202 (may require a second read)
-                elif len(magic_bytes) < 0x206:
-                    magic_bytes += f.read(265)
+                else:
+                    if len(magic_bytes) < 0x206:
+                        magic_bytes += f.read(265)
                     if magic_bytes[0x202:0x206] == b"HdrS":
                         filetype_matches.append("Linux Kernel Image")
                     # Otherwise, call it a PE and be done with it.

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -51,7 +51,6 @@ def is_docker_archive(filepath: str) -> bool:
 
 @surfactant.plugin.hookimpl(tryfirst=True)
 def identify_file_type(filepath: str) -> Optional[str]:
-    # pylint: disable=too-many-return-statements
     filetype_matches = []
     try:
         with open(filepath, "rb") as f:

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -75,10 +75,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 # If coff_addr is still longer than what has been read so far, it points off the end
                 # of the file, so the file is either malformed or something else is up.
                 if coff_addr + 4 > len(magic_bytes):
-                    # return "Malformed PE"
                     filetype_matches.append("Malformed PE")
-                    # do we need to return immediately here?
-                    return filetype_matches
 
                 if magic_bytes[coff_addr : coff_addr + 4] != b"PE\x00\x00":
                     filetype_matches.append("DOS")
@@ -182,6 +179,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 in COFF_MAGIC_TARGET_NAME
             ):
                 filetype_matches.append("COFF")
+            print("filetype: ", filetype_matches)
             # XCOFF:
             # https://www.ibm.com/docs/en/aix/7.3?topic=formats-xcoff-object-file-format
             if magic_bytes[:2] == "\x1d\x00":
@@ -241,7 +239,6 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 if iso_bytes == b"CD001":
                     filetype_matches.append("ISO_9660_CD")
             f.seek(0)
-
             # MacOS dmg:
             # https://en.wikipedia.org/wiki/List_of_file_signatures
             file_size = f.seek(0, os.SEEK_END)
@@ -250,13 +247,12 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 macos_bytes = f.read(4)
                 if macos_bytes[0:4] == b"koly":
                     filetype_matches.append("MACOS_DMG")
-
             # rpm:
             # https://rpm-software-management.github.io/rpm/manual/
             if magic_bytes[:4] == b"\xed\xab\xee\xdb":
-                return "RPM Package"
+                filetype_matches.append("RPM Package")
 
-            return None
     except FileNotFoundError:
         return None
+
     return filetype_matches

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -179,7 +179,6 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 in COFF_MAGIC_TARGET_NAME
             ):
                 filetype_matches.append("COFF")
-            print("filetype: ", filetype_matches)
             # XCOFF:
             # https://www.ibm.com/docs/en/aix/7.3?topic=formats-xcoff-object-file-format
             if magic_bytes[:2] == "\x1d\x00":

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -52,11 +52,12 @@ def is_docker_archive(filepath: str) -> bool:
 @surfactant.plugin.hookimpl(tryfirst=True)
 def identify_file_type(filepath: str) -> Optional[str]:
     # pylint: disable=too-many-return-statements
+    filetype_matches = []
     try:
         with open(filepath, "rb") as f:
             magic_bytes = f.read(265)
             if magic_bytes[:4] == b"\x7fELF":
-                return "ELF"
+                filetype_matches.append("ELF")
             if magic_bytes[:2] == b"MZ":
                 # Several file types start with the same `MZ` signature, so we need to handle them.
                 # Regardless, the initial header (may) contain a pointer to an additional COFF
@@ -74,134 +75,137 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 # If coff_addr is still longer than what has been read so far, it points off the end
                 # of the file, so the file is either malformed or something else is up.
                 if coff_addr + 4 > len(magic_bytes):
-                    return "Malformed PE"
+                    # return "Malformed PE"
+                    filetype_matches.append("Malformed PE")
+                    # do we need to return immediately here?
+                    return filetype_matches
 
                 if magic_bytes[coff_addr : coff_addr + 4] != b"PE\x00\x00":
-                    return "DOS"
+                    filetype_matches.append("DOS")
 
                 # Check for the linux kernel header at 0x202 (may require a second read)
                 if len(magic_bytes) < 0x206:
                     magic_bytes += f.read(265)
 
                 if magic_bytes[0x202:0x206] == b"HdrS":
-                    return "Linux Kernel Image"
+                    filetype_matches.append("Linux Kernel Image")
 
                 # Otherwise, call it a PE and be done with it.
-                return "PE"
+                filetype_matches.append("PE")
 
             if magic_bytes[:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
                 # MSI (install), MSP (patch), MST (transform), and MSM (merge) files are all types of OLE files
                 # the root storage object CLSID is used to identify what it is (+ file extension)
-                return "OLE"
+                filetype_matches.append("OLE")
             # Microsoft CAB files
             if magic_bytes[:4] == b"MSCF":
-                return "MSCAB"
+                filetype_matches.append("MSCAB")
             # InstallShield CAB files
             if magic_bytes[:4] == b"ISc(":
-                return "ISCAB"
+                filetype_matches.append("ISCAB")
             # For gzipped data, also filter by extension to avoid huge number of entries with limited info
             if magic_bytes[:2] == b"\x1f\x8b":
                 if is_docker_archive(filepath):
-                    return "DOCKER_GZIP"
-                return "GZIP"
+                    filetype_matches.append("DOCKER_GZIP")
+                filetype_matches.append("GZIP")
             # Check for compressed TAR files (tar.bz2, tar.xz)
             if magic_bytes[:3] == b"BZh":
-                return "BZIP2"
+                filetype_matches.append("BZIP2")
             if magic_bytes[:6] == b"\xfd\x37\x7a\x58\x5a\x00":
-                return "XZ"
+                filetype_matches.append("XZ")
             if magic_bytes[257:265] == b"ustar\x0000" or magic_bytes[257:265] == b"ustar  \x00":
                 if is_docker_archive(filepath):
-                    return "DOCKER_TAR"
-                return "TAR"
+                    filetype_matches.append("DOCKER_TAR")
+                filetype_matches.append("TAR")
             if magic_bytes[:6] == b"\x52\x61\x72\x21\x1a\x07":
-                return "RAR"
+                filetype_matches.append("RAR")
             if magic_bytes[:4] in [b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"]:
                 suffix = pathlib.Path(filepath).suffix.lower()
                 if suffix in [".zip", ".zipx"]:
-                    return "ZIP"
+                    filetype_matches.append("ZIP")
                 # Java archive files of various types
                 if suffix == ".jar":
-                    return "JAR"
+                    filetype_matches.append("JAR")
                 if suffix == ".war":
-                    return "WAR"
+                    filetype_matches.append("WAR")
                 if suffix == ".ear":
-                    return "EAR"
+                    filetype_matches.append("EAR")
                 # Android packages
                 if suffix == ".apk":
-                    return "APK"
+                    filetype_matches.append("APK")
                 # iOS/iPad applications
                 if suffix == ".ipa":
-                    return "IPA"
+                    filetype_matches.append("IPA")
                 # Windows app package
                 if suffix == ".msix":
-                    return "MSIX"
+                    filetype_matches.append("MSIX")
             # Magic for Java and Mach-O FAT Binary are the same
             if magic_bytes[:4] == b"\xca\xfe\xba\xbe":
                 # Distinguish them the same way file magic and Apple do
                 # https://opensource.apple.com/source/file/file-80.40.2/file/magic/Magdir/cafebabe.auto.html
                 # https://github.com/file/file/blob/master/magic/Magdir/cafebabe
                 if int.from_bytes(magic_bytes[4:8], byteorder="big", signed=False) <= 30:
-                    return "MACHOFAT"
-                return "JAVACLASS"
+                    filetype_matches.append("MACHOFAT")
+                filetype_matches.append("JAVACLASS")
             if magic_bytes[:4] == b"\xbe\xba\xfe\xca":
-                return "MACHOFAT"
+                filetype_matches.append("MACHOFAT")
             if magic_bytes[:4] in [b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca"]:
-                return "MACHOFAT64"
+                filetype_matches.append("MACHOFAT64")
             # Apple fat EFI binaries
             if magic_bytes[:4] == b"\x0e\xf1\xfa\b9":
-                return "EFIFAT"
+                filetype_matches.append("EFIFAT")
             # NOTE: the MACH032 and MACHO64 (normal byte order) magic may be located
             # at offset 0x1000 in some files
             if magic_bytes[:4] in [b"\xfe\xed\xfa\xce", b"\xce\xfa\xed\xfe"]:
-                return "MACHO32"
+                filetype_matches.append("MACHO32")
             if magic_bytes[:4] in [b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe"]:
-                return "MACHO64"
+                filetype_matches.append("MACHO64")
             # https://releases.llvm.org/2.7/docs/BitCodeFormat.html#magic
             if magic_bytes[:4] == b"\xde\xc0\x17\x0b":
-                return "LLVM_BITCODE"
+                filetype_matches.append("LLVM_BITCODE")
             if magic_bytes[:4] == b"BC\xc0\xde":
-                return "LLVM_IR"
+                filetype_matches.append("LLVM_IR")
             # Need to check both small and big endian for a.out
             a_out_magic = [0x111, 0x108, 0x107, 0x0CC, 0x10B]
             if (
                 int.from_bytes(magic_bytes[:4], byteorder="big", signed=False) & 0xFFFF
                 in a_out_magic
             ):
-                return "A.OUT big"
+                filetype_matches.append("A.OUT big")
             if (
                 int.from_bytes(magic_bytes[:4], byteorder="little", signed=False) & 0xFFFF
                 in a_out_magic
             ):
-                return "A.OUT little"
+                filetype_matches.append("A.OUT little")
             if (
                 int.from_bytes(magic_bytes[:2], byteorder="little", signed=False)
                 in COFF_MAGIC_TARGET_NAME
             ):
-                return "COFF"
+                filetype_matches.append("COFF")
             # XCOFF:
             # https://www.ibm.com/docs/en/aix/7.3?topic=formats-xcoff-object-file-format
             if magic_bytes[:2] == "\x1d\x00":
-                return "XCOFF32"
+                filetype_matches.append("XCOFF32")
             if magic_bytes[:2] == "\xf7\x01":
-                return "XCOFF64"
+                filetype_matches.append("XCOFF64")
             # ECOFF:
             # https://web.archive.org/web/20160305114748/http://h41361.www4.hp.com/docs/base_doc/DOCUMENTATION/V50A_ACRO_SUP/OBJSPEC.PDF
             if magic_bytes[:2] in ("\x83\x01", "\x88\x01", "\x8f\x01"):
-                return "ECOFF"
+                filetype_matches.append("ECOFF")
             # AR:
             # https://www.garykessler.net/library/file_sigs.html
             if magic_bytes[:8] == b"!<arch>\n":
-                return "AR_LIB"
+                filetype_matches.append("AR_LIB")
             # OMF:
             # https://github.com/file/file/blob/c8bba134ac1f3c9f5/magic/Magdir/msvc#L22
             if (
                 int.from_bytes(magic_bytes[0:4], byteorder="big", signed=False) & 0xFF0F80FF
             ) == 0xF00D0000:
-                return "OMF_LIB"
+                filetype_matches.append("OMF_LIB")
             # U-Boot/uImage
             # https://github.com/u-boot/u-boot/blob/master/include/image.h#L313
             if magic_bytes[:4] == b"\x27\x05\x19\x56":
-                return "UIMAGE"
+                filetype_matches.append("UIMAGE")
             # zlib:
             # https://www.rfc-editor.org/rfc/rfc1950
             if len(magic_bytes) >= 2:
@@ -210,32 +214,32 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 cm = cmf & 0x0F
                 if cm == 8:
                     if (cmf * 256 + flg) % 31 == 0:
-                        return "ZLIB"
+                        filetype_matches.append("ZLIB")
             # cpio:
             # https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/cpio/CpioArchiveEntry.html
             if int.from_bytes(magic_bytes[:2], byteorder="big", signed=False) == 0o70707:
-                return "CPIO_BIN big"
+                filetype_matches.append("CPIO_BIN big")
             if int.from_bytes(magic_bytes[:2], byteorder="little", signed=False) == 0o70707:
-                return "CPIO_BIN little"
+                filetype_matches.append("CPIO_BIN little")
             if magic_bytes[:6] == b"070707":
-                return "CPIO_ASCII_OLD"
+                filetype_matches.append("CPIO_ASCII_OLD")
             if magic_bytes[:6] == b"070701":
-                return "CPIO_ASCII_NEW"
+                filetype_matches.append("CPIO_ASCII_NEW")
             if magic_bytes[:6] == b"070702":
-                return "CPIO_ASCII_NEW_CRC"
+                filetype_matches.append("CPIO_ASCII_NEW_CRC")
             # zstd:
             # https://datatracker.ietf.org/doc/html/rfc8878
             if magic_bytes[:4] == b"\x28\xb5\x2f\xfd":
-                return "ZSTANDARD"
+                filetype_matches.append("ZSTANDARD")
             if magic_bytes[:4] == b"\x37\xa4\x30\xec":
-                return "ZSTANDARD_DICTIONARY"
+                filetype_matches.append("ZSTANDARD_DICTIONARY")
             # iso:
             # https://en.wikipedia.org/wiki/List_of_file_signatures
             for offset in (0x8001, 0x8801, 0x9001):
                 f.seek(offset)
                 iso_bytes = f.read(5)
                 if iso_bytes == b"CD001":
-                    return "ISO_9660_CD"
+                    filetype_matches.append("ISO_9660_CD")
             f.seek(0)
 
             # MacOS dmg:
@@ -245,7 +249,7 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 f.seek(-512, os.SEEK_END)
                 macos_bytes = f.read(4)
                 if macos_bytes[0:4] == b"koly":
-                    return "MACOS_DMG"
+                    filetype_matches.append("MACOS_DMG")
 
             # rpm:
             # https://rpm-software-management.github.io/rpm/manual/
@@ -255,3 +259,4 @@ def identify_file_type(filepath: str) -> Optional[str]:
             return None
     except FileNotFoundError:
         return None
+    return filetype_matches

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -80,10 +80,6 @@ def identify_file_type(filepath: str) -> Optional[str]:
                     magic_bytes += f.read(265)
                     if magic_bytes[0x202:0x206] == b"HdrS":
                         filetype_matches.append("Linux Kernel Image")
-                    else:
-                        filetype_matches.append("PE")
-                elif magic_bytes[0x202:0x206] == b"HdrS":
-                    filetype_matches.append("Linux Kernel Image")
                 # Otherwise, call it a PE and be done with it.
                 else:
                     filetype_matches.append("PE")

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -80,9 +80,9 @@ def identify_file_type(filepath: str) -> Optional[str]:
                     magic_bytes += f.read(265)
                     if magic_bytes[0x202:0x206] == b"HdrS":
                         filetype_matches.append("Linux Kernel Image")
-                # Otherwise, call it a PE and be done with it.
-                else:
-                    filetype_matches.append("PE")
+                    # Otherwise, call it a PE and be done with it.
+                    else:
+                        filetype_matches.append("PE")
 
             if magic_bytes[:8] == b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1":
                 # MSI (install), MSP (patch), MST (transform), and MSM (merge) files are all types of OLE files

--- a/surfactant/infoextractors/coff_file.py
+++ b/surfactant/infoextractors/coff_file.py
@@ -2,19 +2,23 @@
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+from typing import List
+
 import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
 
 
-def supports_file(filetype: str) -> bool:
-    return filetype == "COFF"
+def supports_file(filetype: List[str]) -> bool:
+    if "COFF" in filetype:
+        return True
+    return False
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
-    return extract_coff_out_info(filetype, filename)
+    return extract_coff_out_info(filename)
 
 
 # Machine types:
@@ -33,7 +37,7 @@ COFF_MAGIC_TARGET_NAME = {
 }
 
 
-def extract_coff_out_info(filetype: str, filename: str) -> object:
+def extract_coff_out_info(filename: str) -> object:
     try:
         with open(filename, "rb") as f:
             magic_bytes = f.read(4)

--- a/surfactant/infoextractors/coff_file.py
+++ b/surfactant/infoextractors/coff_file.py
@@ -9,9 +9,7 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 def supports_file(filetype: List[str]) -> bool:
-    if "COFF" in filetype:
-        return True
-    return False
+    return "COFF" in filetype
 
 
 @surfactant.plugin.hookimpl

--- a/surfactant/infoextractors/docker_image.py
+++ b/surfactant/infoextractors/docker_image.py
@@ -6,7 +6,7 @@ import gzip
 import json
 import subprocess
 import tempfile
-from typing import Optional
+from typing import List, Optional
 
 from loguru import logger
 
@@ -70,22 +70,24 @@ class DockerScoutManager:
 dsManager = DockerScoutManager()
 
 
-def supports_file(filetype: str) -> bool:
+def supports_file(filetype: List[str]) -> bool:
     """Check if the file type is supported."""
-    return filetype in ("DOCKER_TAR", "DOCKER_GZIP")
+    if "DOCKER_TAR" in filetype or "DOCKER_GZIP" in filetype:
+        return True
+    return False
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     """Extract file information using Docker Scout if supported."""
     if dsManager.disable_docker_scout or not supports_file(filetype):
         return None
     return extract_docker_info(filetype, filename)
 
 
-def extract_docker_info(filetype: str, filename: str) -> object:
+def extract_docker_info(filetype: List[str], filename: str) -> object:
     """Extract Docker information based on file type."""
-    if filetype == "DOCKER_GZIP":
+    if "DOCKER_GZIP" in filetype:
         with open(filename, "rb") as gzip_in:
             gzip_data = gzip_in.read()
         with tempfile.NamedTemporaryFile() as gzip_out:

--- a/surfactant/infoextractors/elf_file.py
+++ b/surfactant/infoextractors/elf_file.py
@@ -16,7 +16,7 @@ import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
 
 
-def supports_file(filetype) -> bool:
+def supports_file(filetype: List[str]) -> bool:
     return "ELF" in filetype
 
 

--- a/surfactant/infoextractors/elf_file.py
+++ b/surfactant/infoextractors/elf_file.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 import struct
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from elftools.common.exceptions import ELFError, ELFParseError
 from elftools.elf.dynamic import DynamicSection
@@ -17,11 +17,11 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 def supports_file(filetype) -> bool:
-    return filetype == "ELF"
+    return "ELF" in filetype
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
     return extract_elf_info(filename)

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -33,11 +33,18 @@ GLOBAL_TEMP_DIRS_LIST = []
 RAR_SUPPORT = {"enabled": True}
 
 
-def supports_file(filetype: str) -> Optional[str]:
-    if filetype in {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"} or (
-        filetype == "RAR" and RAR_SUPPORT["enabled"]
-    ):
-        return filetype
+def supports_file(filetype: list[str]) -> Optional[list[str]]:
+    supported_types = {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"}
+    supported = []
+    # Filter out non-archive types
+    for ft in filetype:
+        if ft in supported_types:
+            supported.append(ft)
+        elif ft == "RAR" and RAR_SUPPORT["enabled"]:
+            supported.append(ft)
+    if supported:
+        return supported
+
     return None
 
 
@@ -47,7 +54,7 @@ def extract_file_info(
     sbom: SBOM,
     software: Software,
     filename: str,
-    filetype: str,
+    filetype: List[str],
     context_queue: "Queue[ContextEntry]",
     current_context: Optional[ContextEntry],
 ) -> Optional[Dict[str, Any]]:

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -34,6 +34,8 @@ RAR_SUPPORT = {"enabled": True}
 
 
 def supports_file(filetype: list[str]) -> Optional[list[str]]:
+    if filetype is None:
+        return None
     supported_types = {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"}
     supported = []
     # Filter out non-archive types
@@ -62,12 +64,13 @@ def extract_file_info(
     compression_format = supports_file(filetype)
 
     if compression_format:
-        create_extraction(
-            filename,
-            context_queue,
-            current_context,
-            lambda f, t: decompress_to(f, t, compression_format),
-        )
+        for fmt in compression_format:
+            create_extraction(
+                filename,
+                context_queue,
+                current_context,
+                lambda f, t, fmt=fmt: decompress_to(f, t, fmt),
+            )
 
 
 # decompress takes a filename and an output folder, and decompresses the file into that folder.

--- a/surfactant/infoextractors/java_file.py
+++ b/surfactant/infoextractors/java_file.py
@@ -1,9 +1,14 @@
 <<<<<<< HEAD
+<<<<<<< HEAD
 from sys import modules
 from typing import Any, Dict
 =======
 from typing import Any, Dict, List
 >>>>>>> 6212ffa (changing filetype to list[str])
+=======
+from sys import modules
+from typing import Any, Dict
+>>>>>>> 71977f3 (fix id_extension.py)
 
 try:
     import javatools.jarinfo
@@ -18,16 +23,12 @@ from surfactant.sbomtypes import SBOM, Software
 # https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst
 
 
-def supports_file(filetype: List[str]) -> bool:
-    supported_types = ("JAVACLASS", "JAR", "WAR", "EAR")
-    for ft in filetype:
-        if ft in supported_types:
-            return True
-    return False
+def supports_file(filetype: str) -> bool:
+    return filetype in ("JAVACLASS", "JAR", "WAR", "EAR")
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
     if not supports_file(filetype):
         return None
     if "javatools" not in modules:
@@ -88,13 +89,13 @@ def handle_java_class(info: Dict[str, Any], class_info: "javatools.JavaClassInfo
         add_to["javaImports"] = []
 
 
-def extract_java_info(filename: str, filetype: List[str]) -> object:
+def extract_java_info(filename: str, filetype: str) -> object:
     info: Dict[str, Any] = {"javaClasses": {}}
-    if "JAR" in filetype or "EAR" in filetype or "WAR" in filetype:
+    if filetype in ("JAR", "EAR", "WAR"):
         with javatools.jarinfo.JarInfo(filename) as jarinfo:
             for class_ in jarinfo.get_classes():
                 handle_java_class(info, jarinfo.get_classinfo(class_))
-    elif "JAVACLASS" in filetype:
+    elif filetype == "JAVACLASS":
         with open(filename, "rb") as f:
             class_info = javatools.JavaClassInfo()
             class_info.unpack(javatools.unpack(f))

--- a/surfactant/infoextractors/java_file.py
+++ b/surfactant/infoextractors/java_file.py
@@ -1,5 +1,9 @@
+<<<<<<< HEAD
 from sys import modules
 from typing import Any, Dict
+=======
+from typing import Any, Dict, List
+>>>>>>> 6212ffa (changing filetype to list[str])
 
 try:
     import javatools.jarinfo
@@ -14,12 +18,16 @@ from surfactant.sbomtypes import SBOM, Software
 # https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst
 
 
-def supports_file(filetype: str) -> bool:
-    return filetype in ("JAVACLASS", "JAR", "WAR", "EAR")
+def supports_file(filetype: List[str]) -> bool:
+    supported_types = ("JAVACLASS", "JAR", "WAR", "EAR")
+    for ft in filetype:
+        if ft in supported_types:
+            return True
+    return False
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
     if "javatools" not in modules:
@@ -80,13 +88,13 @@ def handle_java_class(info: Dict[str, Any], class_info: "javatools.JavaClassInfo
         add_to["javaImports"] = []
 
 
-def extract_java_info(filename: str, filetype: str) -> object:
+def extract_java_info(filename: str, filetype: List[str]) -> object:
     info: Dict[str, Any] = {"javaClasses": {}}
-    if filetype in ("JAR", "EAR", "WAR"):
+    if "JAR" in filetype or "EAR" in filetype or "WAR" in filetype:
         with javatools.jarinfo.JarInfo(filename) as jarinfo:
             for class_ in jarinfo.get_classes():
                 handle_java_class(info, jarinfo.get_classinfo(class_))
-    elif filetype == "JAVACLASS":
+    elif "JAVACLASS" in filetype:
         with open(filename, "rb") as f:
             class_info = javatools.JavaClassInfo()
             class_info.unpack(javatools.unpack(f))

--- a/surfactant/infoextractors/java_file.py
+++ b/surfactant/infoextractors/java_file.py
@@ -1,14 +1,5 @@
-<<<<<<< HEAD
-<<<<<<< HEAD
 from sys import modules
 from typing import Any, Dict
-=======
-from typing import Any, Dict, List
->>>>>>> 6212ffa (changing filetype to list[str])
-=======
-from sys import modules
-from typing import Any, Dict
->>>>>>> 71977f3 (fix id_extension.py)
 
 try:
     import javatools.jarinfo

--- a/surfactant/infoextractors/java_file.py
+++ b/surfactant/infoextractors/java_file.py
@@ -1,5 +1,5 @@
 from sys import modules
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 try:
     import javatools.jarinfo
@@ -14,12 +14,16 @@ from surfactant.sbomtypes import SBOM, Software
 # https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst
 
 
-def supports_file(filetype: str) -> bool:
-    return filetype in ("JAVACLASS", "JAR", "WAR", "EAR")
+def supports_file(filetype: List[str]) -> bool:
+    supported_types = ("JAVACLASS", "JAR", "WAR", "EAR")
+    for ft in filetype:
+        if ft in supported_types:
+            return True
+    return False
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
     if "javatools" not in modules:
@@ -80,13 +84,13 @@ def handle_java_class(info: Dict[str, Any], class_info: "javatools.JavaClassInfo
         add_to["javaImports"] = []
 
 
-def extract_java_info(filename: str, filetype: str) -> object:
+def extract_java_info(filename: str, filetype: List[str]) -> object:
     info: Dict[str, Any] = {"javaClasses": {}}
-    if filetype in ("JAR", "EAR", "WAR"):
+    if "JAR" in filetype or "EAR" in filetype or "WAR" in filetype:
         with javatools.jarinfo.JarInfo(filename) as jarinfo:
             for class_ in jarinfo.get_classes():
                 handle_java_class(info, jarinfo.get_classinfo(class_))
-    elif filetype == "JAVACLASS":
+    elif "JAVACLASS" in filetype:
         with open(filename, "rb") as f:
             class_info = javatools.JavaClassInfo()
             class_info.unpack(javatools.unpack(f))

--- a/surfactant/infoextractors/js_file.py
+++ b/surfactant/infoextractors/js_file.py
@@ -96,7 +96,7 @@ class RetireJSDatabaseManager(BaseDatabaseManager):
 js_db_manager = RetireJSDatabaseManager()
 
 
-def supports_file(filetype) -> bool:
+def supports_file(filetype: List[str]) -> bool:
     return "JAVASCRIPT" in filetype
 
 

--- a/surfactant/infoextractors/js_file.py
+++ b/surfactant/infoextractors/js_file.py
@@ -97,11 +97,11 @@ js_db_manager = RetireJSDatabaseManager()
 
 
 def supports_file(filetype) -> bool:
-    return filetype == "JAVASCRIPT"
+    return "JAVASCRIPT" in filetype
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
     return extract_js_info(filename)

--- a/surfactant/infoextractors/mach_o_file.py
+++ b/surfactant/infoextractors/mach_o_file.py
@@ -7,7 +7,7 @@
 # https://lief.re/doc/stable/api/python/macho.html
 
 from sys import modules
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from loguru import logger
 
@@ -27,12 +27,16 @@ __include_bindings_exports = __config_manager.get("macho", "include_bindings_exp
 __include_signature_content = __config_manager.get("macho", "include_signature_content", False)
 
 
-def supports_file(filetype) -> bool:
-    return filetype in ("MACHOFAT", "MACHOFAT64", "MACHO32", "MACHO64")
+def supports_file(filetype: List[str]) -> bool:
+    supported_types = ("MACHOFAT", "MACHOFAT64", "MACHO32", "MACHO64")
+    for ft in filetype:
+        if ft in supported_types:
+            return True
+    return False
 
 
 @surfactant.plugin.hookimpl
-def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: str) -> object:
+def extract_file_info(sbom: SBOM, software: Software, filename: str, filetype: List[str]) -> object:
     if not supports_file(filetype):
         return None
     if "lief" not in modules:

--- a/surfactant/infoextractors/native_lib_file.py
+++ b/surfactant/infoextractors/native_lib_file.py
@@ -131,13 +131,17 @@ class EmbaNativeLibDatabaseManager(BaseDatabaseManager):
 native_lib_manager = EmbaNativeLibDatabaseManager()
 
 
-def supports_file(filetype: str) -> bool:
-    return filetype in ("PE", "ELF", "MACHOFAT", "MACHOFAT64", "MACHO32", "MACHO64", "UIMAGE")
+def supports_file(filetype: List[str]) -> bool:
+    supported_types = ("PE", "ELF", "MACHOFAT", "MACHOFAT64", "MACHO32", "MACHO64", "UIMAGE")
+    for ft in filetype:
+        if ft in supported_types:
+            return True
+    return False
 
 
 @surfactant.plugin.hookimpl
 def extract_file_info(
-    sbom: SBOM, software: Software, filename: str, filetype: str
+    sbom: SBOM, software: Software, filename: str, filetype: List[str]
 ) -> Optional[Dict[str, Any]]:
     if not supports_file(filetype):
         return None

--- a/surfactant/infoextractors/ole_file.py
+++ b/surfactant/infoextractors/ole_file.py
@@ -61,8 +61,8 @@ def replace_root_id(system_folder_id: str) -> Optional[str]:
     return path
 
 
-def supports_file(filetype) -> bool:
-    return filetype == "OLE"
+def supports_file(filetype: List[str]) -> bool:
+    return "OLE" in filetype
 
 
 # pylint: disable=too-many-positional-arguments
@@ -71,7 +71,7 @@ def extract_file_info(
     sbom: SBOM,
     software: Software,
     filename: str,
-    filetype: str,
+    filetype: List[str],
     software_field_hints: List[Tuple[str, object, int]],
     context_queue: "Queue[ContextEntry]",
     current_context: Optional[ContextEntry],

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -21,8 +21,7 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 def supports_file(filetype: List[str]) -> bool:
-    # return "PE" in filetype
-    return filetype == "PE"
+    return "PE" in filetype
 
 
 @surfactant.plugin.hookimpl
@@ -37,8 +36,11 @@ def extract_file_info(
         return None
     print("PE support")
     pe_info = extract_pe_info(filename)
+    print("1")
     if pe_info:
+        print("2")
         if "FileInfo" in pe_info:
+            print("3")
             fi = pe_info["FileInfo"]
             if "ProductName" in fi:
                 software_field_hints.append(("name", fi["ProductName"], 80))
@@ -116,8 +118,11 @@ pe_subsystem_types = {
 
 
 def extract_pe_info(filename: str) -> object:
+    print("in side extract")
     try:
+        print("in side extract 2")
         pe = dnfile.dnPE(filename, fast_load=False)
+        print("in side extract 3")
     except (OSError, dnfile.PEFormatError):
         return {}
 
@@ -284,8 +289,9 @@ def get_assemblyref_info(asmref_info) -> Dict[str, Any]:
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L62-L66
     # HeapItemBinary value is the bytes following the compressed int (indicating the length)
     # raw_data attribute has the compressed int indicating length included
+
     asmref["HashValue"] = asmref_info.HashValue.value.hex()
-    add_assembly_flags_info(asmref, asmref_info)
+    hash_value = getattr(asmref_info, "HashValue", None)
     return asmref
 
 

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -21,7 +21,8 @@ from surfactant.sbomtypes import SBOM, Software
 
 
 def supports_file(filetype: List[str]) -> bool:
-    return "PE" in filetype
+    # return "PE" in filetype
+    return filetype == "PE"
 
 
 @surfactant.plugin.hookimpl

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -20,8 +20,8 @@ import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
 
 
-def supports_file(filetype) -> bool:
-    return filetype == "PE"
+def supports_file(filetype: List[str]) -> bool:
+    return "PE" in filetype
 
 
 @surfactant.plugin.hookimpl
@@ -29,11 +29,12 @@ def extract_file_info(
     sbom: SBOM,
     software: Software,
     filename: str,
-    filetype: str,
+    filetype: List[str],
     software_field_hints: List[Tuple[str, object, int]],
 ) -> object:
     if not supports_file(filetype):
         return None
+    print("PE support")
     pe_info = extract_pe_info(filename)
     if pe_info:
         if "FileInfo" in pe_info:

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -34,13 +34,9 @@ def extract_file_info(
 ) -> object:
     if not supports_file(filetype):
         return None
-    print("PE support")
     pe_info = extract_pe_info(filename)
-    print("1")
     if pe_info:
-        print("2")
         if "FileInfo" in pe_info:
-            print("3")
             fi = pe_info["FileInfo"]
             if "ProductName" in fi:
                 software_field_hints.append(("name", fi["ProductName"], 80))
@@ -118,11 +114,8 @@ pe_subsystem_types = {
 
 
 def extract_pe_info(filename: str) -> object:
-    print("in side extract")
     try:
-        print("in side extract 2")
         pe = dnfile.dnPE(filename, fast_load=False)
-        print("in side extract 3")
     except (OSError, dnfile.PEFormatError):
         return {}
 
@@ -291,7 +284,7 @@ def get_assemblyref_info(asmref_info) -> Dict[str, Any]:
     # raw_data attribute has the compressed int indicating length included
 
     asmref["HashValue"] = asmref_info.HashValue.value.hex()
-    hash_value = getattr(asmref_info, "HashValue", None)
+    add_assembly_flags_info(asmref, asmref_info)
     return asmref
 
 

--- a/surfactant/infoextractors/uimage_file.py
+++ b/surfactant/infoextractors/uimage_file.py
@@ -218,8 +218,8 @@ def _parse_uimage_header(fname: str) -> dict:
     }
 
 
-def supports_file(filetype) -> bool:
-    return filetype == "UIMAGE"
+def supports_file(filetype: List[str]) -> bool:
+    return "UIMAGE" in filetype
 
 
 @surfactant.plugin.hookimpl
@@ -227,7 +227,7 @@ def extract_file_info(
     sbom: SBOM,
     software: Software,
     filename: str,
-    filetype: str,
+    filetype: List[str],
     software_field_hints: List[Tuple[str, object, int]],
 ) -> object:
     if not supports_file(filetype):

--- a/surfactant/output/cyclonedx_writer.py
+++ b/surfactant/output/cyclonedx_writer.py
@@ -3,12 +3,13 @@ from collections.abc import Iterable
 from typing import Dict, List, Optional, Tuple
 
 import cyclonedx.output
-from cyclonedx.model import HashAlgorithm, HashType, Tool
+from cyclonedx.model import HashAlgorithm, HashType
 from cyclonedx.model.bom import Bom, BomMetaData
 from cyclonedx.model.bom_ref import BomRef
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalEntity
 from cyclonedx.model.dependency import Dependency
+from cyclonedx.model.tool import Tool
 
 import surfactant.plugin
 from surfactant import __version__ as surfactant_version

--- a/surfactant/output/cyclonedx_writer.py
+++ b/surfactant/output/cyclonedx_writer.py
@@ -3,13 +3,12 @@ from collections.abc import Iterable
 from typing import Dict, List, Optional, Tuple
 
 import cyclonedx.output
-from cyclonedx.model import HashAlgorithm, HashType
+from cyclonedx.model import HashAlgorithm, HashType, Tool
 from cyclonedx.model.bom import Bom, BomMetaData
 from cyclonedx.model.bom_ref import BomRef
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalEntity
 from cyclonedx.model.dependency import Dependency
-from cyclonedx.model.tool import Tool
 
 import surfactant.plugin
 from surfactant import __version__ as surfactant_version

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -34,7 +34,7 @@ def extract_file_info(
     sbom: SBOM,
     software: Software,
     filename: str,
-    filetype: str,
+    filetype: List[str],
     context_queue: "Queue[ContextEntry]",
     current_context: Optional[ContextEntry],
     children: List[Software],
@@ -50,7 +50,7 @@ def extract_file_info(
         sbom (SBOM): The SBOM that the software entry is part of. Can be used to add observations or analysis data.
         software (Software): The software entry the gathered information will be added to.
         filename (str): The full path to the file to extract information from.
-        filetype (str): File type information based on magic bytes.
+        filetype (List[str]): File type information based on magic bytes.
         context_queue (Queue[ContextEntry]): Modifiable queue of entries typically initialized from the input specimen
             config file. Plugins can add new entries to the queue to make Surfactant process additional files/folders.
             Existing plugins should still work without adding this parameter.

--- a/surfactant/plugin/hookspecs.py
+++ b/surfactant/plugin/hookspecs.py
@@ -50,7 +50,7 @@ def extract_file_info(
         sbom (SBOM): The SBOM that the software entry is part of. Can be used to add observations or analysis data.
         software (Software): The software entry the gathered information will be added to.
         filename (str): The full path to the file to extract information from.
-        filetype (List[str]): File type information based on magic bytes.
+        filetype (List[str]): File type information based on magic bytes and other heuristics.
         context_queue (Queue[ContextEntry]): Modifiable queue of entries typically initialized from the input specimen
             config file. Plugins can add new entries to the queue to make Surfactant process additional files/folders.
             Existing plugins should still work without adding this parameter.

--- a/tests/file_types/test_file_magic.py
+++ b/tests/file_types/test_file_magic.py
@@ -45,14 +45,14 @@ def test_magic_id():
     base_path = pathlib.Path(__file__).parent.absolute()
     data_dir = os.path.join(base_path, "..", "data")
     for file_name, file_type in _file_to_file_type.items():
-        assert identify_file_type(os.path.join(data_dir, file_name)) == file_type
+        assert identify_file_type(os.path.join(data_dir, file_name)) == [file_type]
 
 
 def test_zlib_basic(tmp_path):
     for compress_level in range(10):
         write_to = tmp_path / f"basic_{compress_level}.zlib"
         write_to.write_bytes(zlib.compress(b"hello", level=compress_level))
-        assert identify_file_type(write_to) == "ZLIB"
+        assert identify_file_type(write_to) == ["ZLIB"]
 
 
 @pytest.mark.skipif(
@@ -63,4 +63,4 @@ def test_zlib_window(tmp_path):
         for window_size in range(9, 16):
             write_to = tmp_path / f"window_{compress_level}_{window_size}.zlib"
             write_to.write_bytes(zlib.compress(b"hello", level=compress_level, wbits=window_size))
-            assert identify_file_type(write_to) == "ZLIB"
+            assert identify_file_type(write_to) == ["ZLIB"]

--- a/tests/file_types/test_uimage_files.py
+++ b/tests/file_types/test_uimage_files.py
@@ -36,7 +36,7 @@ def test_uimage_files():
     for file_name, expected_values in _uimage_files.items():
         file_path = os.path.join(data_dir, file_name)
         file_type = identify_file_type(file_path)
-        assert file_type == "UIMAGE"
+        assert file_type == ["UIMAGE"]
         sw_field_hints = []
         file_info = extract_file_info(SBOM(), Software(), file_path, file_type, sw_field_hints)
         assert sw_field_hints == [("name", "Test uImage", 40)]
@@ -53,7 +53,7 @@ def test_bad_uimage_file():
     base_path = pathlib.Path(__file__).parent.absolute()
     file_path = os.path.join(base_path, "..", "data", "uimage_files", "bad1.img")
     file_type = identify_file_type(file_path)
-    assert file_type == "UIMAGE"
+    assert file_type == ["UIMAGE"]
     sw_field_hints = []
     file_info = extract_file_info(SBOM(), Software(), file_path, file_type, sw_field_hints)
     assert file_info is None


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will restructure all plugins or hooks that use the `filetype` variable to return lists of identified types instead of a single string. This allows for simple polyglot file detection support. In the near future, we will implement a more robust plugin for detecting polyglot files. 

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Change `filetype` from a str to a List[str].
