### PR TITLE
fix: use project.license SPDX expression instead of deprecated license classifiers

### DIFF
--- a/plugins/binary2strings/pyproject.toml
+++ b/plugins/binary2strings/pyproject.toml
@@ -11,14 +11,13 @@ description = "Surfactant File String Extractor"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "binary2strings",

--- a/plugins/cvebin2vex/pyproject.toml
+++ b/plugins/cvebin2vex/pyproject.toml
@@ -11,14 +11,13 @@ description = "Surfactant binary scanner with vex creation"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "cve-bin-tool",

--- a/plugins/fuzzyhashes/pyproject.toml
+++ b/plugins/fuzzyhashes/pyproject.toml
@@ -11,14 +11,13 @@ description = "Surfactant plugin for generating fuzzy hashes"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "py-tlsh",

--- a/plugins/grype/pyproject.toml
+++ b/plugins/grype/pyproject.toml
@@ -11,14 +11,13 @@ description = "Surfactant plugin for running grype on files"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "loguru",

--- a/plugins/sourcetrail_db_output/pyproject.toml
+++ b/plugins/sourcetrail_db_output/pyproject.toml
@@ -11,14 +11,13 @@ description = "Surfactant plugin for producing Sourcetrail databases for vizuali
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "numbat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ description = "Modular framework to gather file information, analyze dependencie
 readme = "README.md"
 requires-python = ">=3.8.1"
 keywords = ["sbom", "pe", "elf", "ole", "msi"]
-license = {text = "MIT License"}
+license = "MIT"
+license-files = ["LICENSE", "NOTICE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
@@ -37,7 +38,6 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: System",
     "Topic :: Utilities",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "dataclasses_json==0.6.*",


### PR DESCRIPTION
If merged this pull request will use project.license with an SPDX expression in pyproject.toml instead of the no longer supported license classifiers. This can cause an error when trying to do a pip install -e from a source code checkout.