### PR TITLE
fix!: remove deprecated setup.py support for old pip versions

### DIFF
--- a/plugins/grype/setup.py
+++ b/plugins/grype/setup.py
@@ -1,9 +1,0 @@
-# Copyright 2024 Lawrence Livermore National Security, LLC
-# See the top-level LICENSE file for details.
-#
-# SPDX-License-Identifier: MIT
-
-# For compatibility with old versions of tools
-from setuptools import setup
-
-setup()

--- a/plugins/sourcetrail_db_output/setup.py
+++ b/plugins/sourcetrail_db_output/setup.py
@@ -1,9 +1,0 @@
-# Copyright 2024 Lawrence Livermore National Security, LLC
-# See the top-level LICENSE file for details.
-#
-# SPDX-License-Identifier: MIT
-
-# For compatibility with old versions of tools
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-# Copyright 2023 Lawrence Livermore National Security, LLC
-# See the top-level LICENSE file for details.
-#
-# SPDX-License-Identifier: MIT
-
-# For compatibility with old versions of tools
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
If merged this pull request will remove the deprecated setup.py file, so installing with `python setup.py` from source will no longer be allowed. For installing from a source code checkout if you get an error, use a newer version of pip, or install from a pre-built binary wheel.