### PR TITLE
chore!: drop support for obsolete Python 3.8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.10", "3.13"]
+        python-version: ["3.9", "3.10", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/plugins/angrimportfinder/pyproject.toml
+++ b/plugins/angrimportfinder/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant Imported Function Extractor"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = {text = "MIT License"}
 classifiers = [

--- a/plugins/binary2strings/pyproject.toml
+++ b/plugins/binary2strings/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant File String Extractor"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = "MIT"
 classifiers = [

--- a/plugins/checksec.py/pyproject.toml
+++ b/plugins/checksec.py/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant checksec.py"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = {text = "MIT License"}
 classifiers = [

--- a/plugins/cvebin2vex/pyproject.toml
+++ b/plugins/cvebin2vex/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant binary scanner with vex creation"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = "MIT"
 classifiers = [

--- a/plugins/fuzzyhashes/pyproject.toml
+++ b/plugins/fuzzyhashes/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant plugin for generating fuzzy hashes"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = "MIT"
 classifiers = [

--- a/plugins/grype/pyproject.toml
+++ b/plugins/grype/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Surfactant plugin for running grype on files"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = "MIT"
 classifiers = [

--- a/plugins/syft/pyproject.toml
+++ b/plugins/syft/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Surfactant syft"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["surfactant"]
 license = {text = "BSD-3-Clause"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 description = "Modular framework to gather file information, analyze dependencies, and generate an SBOM"
 readme = "README.md"
-requires-python = ">=3.8.1"
+requires-python = ">=3.9"
 keywords = ["sbom", "pe", "elf", "ole", "msi"]
 license = "MIT"
 license-files = ["LICENSE", "NOTICE"]


### PR DESCRIPTION
If merged this pull request will drop support for the now obsolete Python 3.8 version. Users still on Python 3.8 should update to a newer Python version. Code can now use any language features introduced in Python 3.9

This PR will unblock merging #438 