### PR TITLE
Enable Auto-Cancellation of Stale CI Runs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
**Pull Request: Enable Auto-Cancellation of Stale CI Runs**

---

### Description

This PR adds GitHub Actions concurrency settings to both the `pytest.yml` and `test_plugins.yml` workflows. With these changes:

* New runs on the same branch or PR will automatically cancel any in-flight or queued older runs in the same group.
* We ensure that CI resources are focused on the most recent commits, reducing wasted cycles.

---

### Changes

* **Added** a top-level `concurrency` block to:

  * `.github/workflows/pytest.yml`
  * `.github/workflows/test_plugins.yml`
* **Configured**

  ```yaml
  concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
  ```

  to group runs by workflow file and branch/PR ref, and cancel obsolete jobs.

---

### Motivation

* **Faster feedback:** Developers see results for their latest commit without waiting for older builds to complete.
* **Cost savings:** Frees up runners by not executing superseded jobs.
* **Simplicity:** Leverages built-in GitHub Actions features—no external tooling needed.

---

### Verification

1. Push a commit to a branch that already has a queued or running build.
2. Observe that the older build is cancelled immediately upon queuing the new one.
3. Repeat for a pull request to ensure both PR-triggered and push-triggered workflows behave as expected.

---

### Related

* Implemented per GitHub Actions docs: [https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#concurrency](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)
* Resolves part of our CI optimization roadmap.

---

### Checklist

* [x] Workflow files updated in `.github/workflows/`
* [x] Added concurrency settings to both test workflows
* [ ] Manually verified cancellation behavior on a test branch

---

*Once merged, CI will automatically cancel outdated runs, keeping only the latest build per branch or PR.*
