### PR TITLE
Add check before old UUID node deletion

### DIFF
--- a/surfactant/sbomtypes/_sbom.py
+++ b/surfactant/sbomtypes/_sbom.py
@@ -252,7 +252,8 @@ class SBOM:
                     self.graph.add_edge(kept_uuid, dst, key=key, **attrs)
 
                 # remove the old UUID entirely
-                self.graph.remove_node(old_uuid)
+                if self.graph.has_node(old_uuid):
+                    self.graph.remove_node(old_uuid)
                 entry_uuid = kept_uuid
 
             # if a parent/package container was provided, attach a "Contains" edge


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

This PR fixes a crash that occurs when adding a software entry to an SBOM that already exists with the updated networkx graph layout

### Proposed changes

Add check before lines from `_sbom.py` under 10e89bc
```python
# remove the old UUID entirely
self.graph.remove_node(old_uuid)
```
The old UUID may not be in the graph and `remove_node` will throw an exception