### PR TITLE
Use extractcode as stopgap for decompression/extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
     # Pinned to specific version for potential breaking changes
     "networkx>=2.6",
     "python-msi==0.0.0a2",
-    "extractcode>=31.0.0",
 ]
 
 dynamic = ["version"]
@@ -67,7 +66,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 macho = ["lief==0.16.6"]
 java = ["javatools>=1.6,==1.*"]
-extract-full = ["extractcode[full]"]
+extractcode = ["extractcode[full]>=31.0.0"]
 test = ["pytest"]
 dev = ["build", "pre-commit"]
 docs = ["sphinx", "myst-parser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,17 +56,18 @@ dependencies = [
     "tomlkit==0.13.*",
     "textual==3.*",
     "requests>=2.32.3",
-    "rarfile==4.2.*",
     # Pinned to specific version for potential breaking changes
     "networkx>=2.6",
-    "python-msi==0.0.0a2"
-    ]
+    "python-msi==0.0.0a2",
+    "extractcode>=31.0.0",
+]
 
 dynamic = ["version"]
 
 [project.optional-dependencies]
 macho = ["lief==0.16.6"]
 java = ["javatools>=1.6,==1.*"]
+extract-full = ["extractcode[full]"]
 test = ["pytest"]
 dev = ["build", "pre-commit"]
 docs = ["sphinx", "myst-parser"]

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -14,7 +14,11 @@ try:
     from extractcode import sevenzip
 
     EXTRACTCODE_AVAILABLE = True
-except (ImportError, AttributeError, NoMagicLibError) as e:
+# pylint: disable-next=broad-exception-caught
+except Exception as e:
+    # Catch NoMagicLibError and other library-specific errors during import
+    if type(e).__name__ != "NoMagicLibError" and not isinstance(e, ImportError) and not isinstance(e, AttributeError):
+        raise e
     logger.warning(f"extractcode library not available in file type identification: {e}")
     EXTRACTCODE_AVAILABLE = False
     ec_archive = None

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 from typing import Optional
+
 from extractcode import archive as ec_archive
 from extractcode import sevenzip
 
@@ -19,17 +20,19 @@ def identify_file_type(filepath: str) -> Optional[str]:
     except FileNotFoundError:
         return None
 
+
 @surfactant.plugin.hookimpl
 def init_hook(command_name: Optional[str] = None) -> None:
     ec_archive.archive_handlers.append(WimHandler)
 
+
 # Add WIM support to extractcode via 7zip
 WimHandler = ec_archive.Handler(
-    name='Microsoft wim',
-    filetypes=('Windows imaging (WIM) image'),
-    mimetypes=('application/x-ms-wim',),
-    extensions=('.wim',),
+    name="Microsoft wim",
+    filetypes=("Windows imaging (WIM) image"),
+    mimetypes=("application/x-ms-wim",),
+    extensions=(".wim",),
     kind=ec_archive.package,
     extractors=[sevenzip.extract],
-    strict=True
+    strict=True,
 )

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+from typing import Optional
+from extractcode import archive as ec_archive
+from extractcode import sevenzip
+
+import surfactant.plugin
+
+
+@surfactant.plugin.hookimpl
+def identify_file_type(filepath: str) -> Optional[str]:
+    try:
+        ec_handler = ec_archive.get_best_handler(filepath)
+        if ec_handler:
+            return f"EXTRACTCODE-{ec_handler.name}"
+        return None
+    except FileNotFoundError:
+        return None
+
+@surfactant.plugin.hookimpl
+def init_hook(command_name: Optional[str] = None) -> None:
+    ec_archive.archive_handlers.append(WimHandler)
+
+# Add WIM support to extractcode via 7zip
+WimHandler = ec_archive.Handler(
+    name='Microsoft wim',
+    filetypes=('Windows imaging (WIM) image'),
+    mimetypes=('application/x-ms-wim',),
+    extensions=('.wim',),
+    kind=ec_archive.package,
+    extractors=[sevenzip.extract],
+    strict=True
+)

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -5,10 +5,10 @@
 from typing import Optional
 
 from loguru import logger
+from typecode.magic2 import NoMagicLibError
 
 import surfactant.plugin
 
-from typecode.magic2 import NoMagicLibError
 try:
     from extractcode import archive as ec_archive
     from extractcode import sevenzip

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -11,6 +11,7 @@ import surfactant.plugin
 try:
     from extractcode import archive as ec_archive
     from extractcode import sevenzip
+
     EXTRACTCODE_AVAILABLE = True
 except (ImportError, AttributeError) as e:
     logger.warning(f"extractcode library not available in file type identification: {e}")
@@ -23,7 +24,7 @@ except (ImportError, AttributeError) as e:
 def identify_file_type(filepath: str) -> Optional[str]:
     if not EXTRACTCODE_AVAILABLE or ec_archive is None:
         return None
-        
+
     try:
         ec_handler = ec_archive.get_best_handler(filepath)
         if ec_handler:
@@ -45,6 +46,5 @@ def init_hook(command_name: Optional[str] = None) -> None:
             extractors=[sevenzip.extract],
             strict=True,
         )
-            
-        ec_archive.archive_handlers.append(WimHandler)
 
+        ec_archive.archive_handlers.append(WimHandler)

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -8,12 +8,13 @@ from loguru import logger
 
 import surfactant.plugin
 
+from typecode.magic2 import NoMagicLibError
 try:
     from extractcode import archive as ec_archive
     from extractcode import sevenzip
 
     EXTRACTCODE_AVAILABLE = True
-except (ImportError, AttributeError) as e:
+except (ImportError, AttributeError, NoMagicLibError) as e:
     logger.warning(f"extractcode library not available in file type identification: {e}")
     EXTRACTCODE_AVAILABLE = False
     ec_archive = None

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -16,13 +16,7 @@ try:
     EXTRACTCODE_AVAILABLE = True
 # pylint: disable-next=broad-exception-caught
 except Exception as e:
-    # Catch NoMagicLibError and other library-specific errors during import
-    if (
-        type(e).__name__ != "NoMagicLibError"
-        and not isinstance(e, ImportError)
-        and not isinstance(e, AttributeError)
-    ):
-        raise e
+    # Catch any import errors related to extractcode
     logger.warning(f"extractcode library not available in file type identification: {e}")
     EXTRACTCODE_AVAILABLE = False
     ec_archive = None

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -5,7 +5,6 @@
 from typing import Optional
 
 from loguru import logger
-from typecode.magic2 import NoMagicLibError
 
 import surfactant.plugin
 
@@ -17,7 +16,11 @@ try:
 # pylint: disable-next=broad-exception-caught
 except Exception as e:
     # Catch NoMagicLibError and other library-specific errors during import
-    if type(e).__name__ != "NoMagicLibError" and not isinstance(e, ImportError) and not isinstance(e, AttributeError):
+    if (
+        type(e).__name__ != "NoMagicLibError"
+        and not isinstance(e, ImportError)
+        and not isinstance(e, AttributeError)
+    ):
         raise e
     logger.warning(f"extractcode library not available in file type identification: {e}")
     EXTRACTCODE_AVAILABLE = False

--- a/surfactant/filetypeid/id_extractcode.py
+++ b/surfactant/filetypeid/id_extractcode.py
@@ -1,7 +1,8 @@
-# Copyright 2023 Lawrence Livermore National Security, LLC
+# Copyright 2025 Lawrence Livermore National Security, LLC
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
+
 from typing import Optional
 
 from loguru import logger

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -252,6 +252,6 @@ def identify_file_type(filepath: str) -> Optional[str]:
             if magic_bytes[:4] == b"\xed\xab\xee\xdb":
                 return "RPM Package"
 
-            return None
+        return None
     except FileNotFoundError:
         return None

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -8,13 +8,13 @@
 # SPDX-License-Identifier: MIT
 from queue import Queue
 from typing import Any, Dict, Optional
-from extractcode import archive as ec_archive
 
+from extractcode import archive as ec_archive
 from loguru import logger
 
-from surfactant.infoextractors.file_decompression import create_extraction
 import surfactant.plugin
 from surfactant import ContextEntry
+from surfactant.infoextractors.file_decompression import create_extraction
 from surfactant.sbomtypes import SBOM, Software
 
 ADDITIONAL_HANDLERS = {
@@ -42,8 +42,9 @@ ADDITIONAL_HANDLERS = {
     "ZSTANDARD_DICTIONARY",
     "ISO_9660_CD",
     "MACOS_DMG",
-    "RPM Package"
+    "RPM Package",
 }
+
 
 def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
     if not filetype:
@@ -88,15 +89,13 @@ def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler
     elif len(extractors) == 2:
         extractor = lambda f, t: ec_archive.extract_twice(f, t, extractors[0], extractors[1])
     else:
-        logger.error(
-            f"Unsupported number of extractors for {filename}: {len(extractors)}"
-        )
+        logger.error(f"Unsupported number of extractors for {filename}: {len(extractors)}")
         return False
-    
+
     logger.info(f"Extracting {filename} ({handler.name}) to {output_folder} using extractcode")
     warnings = extractor(filename, output_folder)
     if warnings:
         for warning in warnings:
             logger.warning(f"Warning while extracting {filename}: {warning}")
-    
+
     return True

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+from queue import Queue
+from typing import Any, Dict, Optional
+from extractcode import archive as ec_archive
+
+from loguru import logger
+
+from surfactant.infoextractors.file_decompression import create_extraction
+import surfactant.plugin
+from surfactant import ContextEntry
+from surfactant.sbomtypes import SBOM, Software
+
+ADDITIONAL_HANDLERS = {
+    "Linux Kernel Image",
+    "MSCAB",
+    "ISCAB",
+    "DOCKER_GZIP",
+    "GZIP",
+    "BZIP2",
+    "XZ",
+    "DOCKER_TAR",
+    "TAR",
+    "RAR",
+    "ZIP",
+    "JAR",
+    "WAR",
+    "EAR",
+    "APK",
+    "IPA",
+    "MSIX",
+    "ZLIB",
+    "CPIO_BIN big",
+    "CPIO_BIN little",
+    "ZSTANDARD",
+    "ZSTANDARD_DICTIONARY",
+    "ISO_9660_CD",
+    "MACOS_DMG",
+    "RPM Package"
+}
+
+def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
+    if not filetype:
+        return None
+    if filetype.startswith("EXTRACTCODE-"):
+        name = filetype[len("EXTRACTCODE-") :]
+        for handler in ec_archive.archive_handlers:
+            if handler.name == name:
+                return handler
+        logger.error(f"Unknown EXTRACTCODE handler: {name}")
+    handler = ec_archive.get_best_handler(filename)
+    return handler
+
+
+# pylint: disable=too-many-positional-arguments
+@surfactant.plugin.hookimpl
+def extract_file_info(
+    sbom: SBOM,
+    software: Software,
+    filename: str,
+    filetype: str,
+    context_queue: "Queue[ContextEntry]",
+    current_context: Optional[ContextEntry],
+) -> Optional[Dict[str, Any]]:
+    # Check if the file is compressed and get its format
+    handler = get_handler(filename, filetype)
+
+    if handler:
+        create_extraction(
+            filename,
+            context_queue,
+            current_context,
+            lambda f, t: decompress_to(f, t, handler),
+        )
+
+
+def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler) -> bool:
+    extractors = handler.extractors
+    extractor = None
+    if len(extractors) == 1:
+        extractor = extractors[0]
+    elif len(extractors) == 2:
+        extractor = lambda f, t: ec_archive.extract_twice(f, t, extractors[0], extractors[1])
+    else:
+        logger.error(
+            f"Unsupported number of extractors for {filename}: {len(extractors)}"
+        )
+        return False
+    
+    logger.info(f"Extracting {filename} ({handler.name}) to {output_folder} using extractcode")
+    warnings = extractor(filename, output_folder)
+    if warnings:
+        for warning in warnings:
+            logger.warning(f"Warning while extracting {filename}: {warning}")
+    
+    return True

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -9,13 +9,16 @@
 from queue import Queue
 from typing import Any, Dict, Optional
 
-from extractcode import archive as ec_archive
 from loguru import logger
 
 import surfactant.plugin
 from surfactant import ContextEntry
 from surfactant.infoextractors.file_decompression import create_extraction
 from surfactant.sbomtypes import SBOM, Software
+from surfactant.filetypeid.id_extractcode import EXTRACTCODE_AVAILABLE
+
+if EXTRACTCODE_AVAILABLE:
+    from extractcode import archive as ec_archive
 
 ADDITIONAL_HANDLERS = {
     "Linux Kernel Image",
@@ -46,7 +49,10 @@ ADDITIONAL_HANDLERS = {
 }
 
 
-def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
+def get_handler(filename, filetype: str) -> Optional["ec_archive.Handler"]:
+    if not EXTRACTCODE_AVAILABLE:
+        return None
+    
     if not filetype:
         return None
     
@@ -89,7 +95,7 @@ def extract_file_info(
         )
 
 
-def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler) -> bool:
+def decompress_to(filename: str, output_folder: str, handler: "ec_archive.Handler") -> bool:
     extractors = handler.extractors
     extractor = None
     if len(extractors) == 1:

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -13,9 +13,9 @@ from loguru import logger
 
 import surfactant.plugin
 from surfactant import ContextEntry
+from surfactant.filetypeid.id_extractcode import EXTRACTCODE_AVAILABLE
 from surfactant.infoextractors.file_decompression import create_extraction
 from surfactant.sbomtypes import SBOM, Software
-from surfactant.filetypeid.id_extractcode import EXTRACTCODE_AVAILABLE
 
 if EXTRACTCODE_AVAILABLE:
     from extractcode import archive as ec_archive
@@ -52,10 +52,10 @@ ADDITIONAL_HANDLERS = {
 def get_handler(filename, filetype: str) -> Optional["ec_archive.Handler"]:
     if not EXTRACTCODE_AVAILABLE:
         return None
-    
+
     if not filetype:
         return None
-    
+
     # Check if the filetype is an EXTRACTCODE handler
     if filetype.startswith("EXTRACTCODE-"):
         name = filetype[len("EXTRACTCODE-") :]
@@ -63,7 +63,7 @@ def get_handler(filename, filetype: str) -> Optional["ec_archive.Handler"]:
             if handler.name == name:
                 return handler
         logger.error(f"Unknown EXTRACTCODE handler: {name}")
-        
+
     # Additionally handle some more file types that we can already identify from id_magic
     if filetype in ADDITIONAL_HANDLERS:
         handler = ec_archive.get_best_handler(filename)
@@ -101,8 +101,10 @@ def decompress_to(filename: str, output_folder: str, handler: "ec_archive.Handle
     if len(extractors) == 1:
         extractor = extractors[0]
     elif len(extractors) == 2:
+
         def extract_twice(f: str, t: str) -> Any:
             return ec_archive.extract_twice(f, t, extractors[0], extractors[1])
+
         extractor = extract_twice
     else:
         logger.error(f"Unsupported number of extractors for {filename}: {len(extractors)}")

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -95,7 +95,9 @@ def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler
     if len(extractors) == 1:
         extractor = extractors[0]
     elif len(extractors) == 2:
-        extractor = lambda f, t: ec_archive.extract_twice(f, t, extractors[0], extractors[1])
+        def extract_twice(f: str, t: str) -> Any:
+            return ec_archive.extract_twice(f, t, extractors[0], extractors[1])
+        extractor = extract_twice
     else:
         logger.error(f"Unsupported number of extractors for {filename}: {len(extractors)}")
         return False

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: MIT
 from queue import Queue
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from loguru import logger
 
@@ -17,8 +17,10 @@ from surfactant.filetypeid.id_extractcode import EXTRACTCODE_AVAILABLE
 from surfactant.infoextractors.file_decompression import create_extraction
 from surfactant.sbomtypes import SBOM, Software
 
-if EXTRACTCODE_AVAILABLE:
+if EXTRACTCODE_AVAILABLE or TYPE_CHECKING:
     from extractcode import archive as ec_archive
+else:
+    ec_archive = None
 
 ADDITIONAL_HANDLERS = {
     "Linux Kernel Image",
@@ -49,8 +51,8 @@ ADDITIONAL_HANDLERS = {
 }
 
 
-def get_handler(filename, filetype: str) -> Optional["ec_archive.Handler"]:
-    if not EXTRACTCODE_AVAILABLE:
+def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
+    if not EXTRACTCODE_AVAILABLE or ec_archive is None:
         return None
 
     if not filetype:
@@ -95,7 +97,7 @@ def extract_file_info(
         )
 
 
-def decompress_to(filename: str, output_folder: str, handler: "ec_archive.Handler") -> bool:
+def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler) -> bool:
     extractors = handler.extractors
     extractor = None
     if len(extractors) == 1:

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -49,14 +49,22 @@ ADDITIONAL_HANDLERS = {
 def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
     if not filetype:
         return None
+    
+    # Check if the filetype is an EXTRACTCODE handler
     if filetype.startswith("EXTRACTCODE-"):
         name = filetype[len("EXTRACTCODE-") :]
         for handler in ec_archive.archive_handlers:
             if handler.name == name:
                 return handler
         logger.error(f"Unknown EXTRACTCODE handler: {name}")
-    handler = ec_archive.get_best_handler(filename)
-    return handler
+        
+    # Additionally handle some more file types that we can already identify from id_magic
+    if filetype in ADDITIONAL_HANDLERS:
+        handler = ec_archive.get_best_handler(filename)
+        if not handler:
+            logger.warning(f"No handler found for {filetype} ({filename}).")
+        return handler
+    return None
 
 
 # pylint: disable=too-many-positional-arguments

--- a/surfactant/infoextractors/extractcode_file.py
+++ b/surfactant/infoextractors/extractcode_file.py
@@ -2,10 +2,7 @@
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
-# Copyright 2025 Lawrence Livermore National Security, LLC
-# See the top-level LICENSE file for details.
-#
-# SPDX-License-Identifier: MIT
+
 from queue import Queue
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -51,7 +48,7 @@ ADDITIONAL_HANDLERS = {
 }
 
 
-def get_handler(filename, filetype: str) -> Optional[ec_archive.Handler]:
+def get_handler(filename, filetype: str) -> Optional["ec_archive.Handler"]:
     if not EXTRACTCODE_AVAILABLE or ec_archive is None:
         return None
 
@@ -97,7 +94,7 @@ def extract_file_info(
         )
 
 
-def decompress_to(filename: str, output_folder: str, handler: ec_archive.Handler) -> bool:
+def decompress_to(filename: str, output_folder: str, handler: "ec_archive.Handler") -> bool:
     extractors = handler.extractors
     extractor = None
     if len(extractors) == 1:

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -23,11 +23,11 @@ from loguru import logger
 
 import surfactant.plugin
 from surfactant import ContextEntry
-from surfactant.configmanager import ConfigManager
 from surfactant.sbomtypes import SBOM, Software
 
 # Global list to track temp dirs
 GLOBAL_TEMP_DIRS_LIST = []
+
 
 def supports_file(filetype: str) -> Optional[str]:
     if filetype in {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"}:

--- a/surfactant/infoextractors/file_decompression.py
+++ b/surfactant/infoextractors/file_decompression.py
@@ -19,7 +19,6 @@ import zipfile
 from queue import Queue
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
-import rarfile
 from loguru import logger
 
 import surfactant.plugin
@@ -30,13 +29,8 @@ from surfactant.sbomtypes import SBOM, Software
 # Global list to track temp dirs
 GLOBAL_TEMP_DIRS_LIST = []
 
-RAR_SUPPORT = {"enabled": True}
-
-
 def supports_file(filetype: str) -> Optional[str]:
-    if filetype in {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"} or (
-        filetype == "RAR" and RAR_SUPPORT["enabled"]
-    ):
+    if filetype in {"TAR", "GZIP", "ZIP", "BZIP2", "XZ"}:
         return filetype
     return None
 
@@ -143,8 +137,6 @@ def decompress_to(filename: str, output_folder: str, compression_format: str) ->
                 )
             # Since it doesn't seem to be a compressed tar file, try just decompressing the file
             return decompress_file(filename, output_folder, compression_format)
-    elif compression_format == "RAR":
-        decompress_rar_file(filename, output_folder)
     else:
         raise ValueError(f"Unsupported compression format: {compression_format}")
     return True
@@ -222,38 +214,14 @@ def extract_tar_file(
     logger.info(f"Extracted TAR contents to {output_folder}")
 
 
-def decompress_rar_file(filename: str, output_folder: str):
-    try:
-        rf = rarfile.RarFile(filename)
-        rf.extractall(path=output_folder)
-    except rarfile.Error as e:
-        logger.error(f"Error extracting rar file: {e}")
-    logger.info(f"Extracted RAR contents to {output_folder}")
-
-
 def delete_temp_dirs():
     for temp_dir in GLOBAL_TEMP_DIRS_LIST:
         if temp_dir and os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir)
-            logger.info(f"Cleaned up temporary directory: {temp_dir}")
-
-
-@surfactant.plugin.hookimpl
-def init_hook(command_name: Optional[str] = None) -> None:
-    RAR_SUPPORT["enabled"] = False
-
-    should_enable_rar = ConfigManager().get("rar", "enabled", True)
-    if should_enable_rar:
-        try:
-            result = rarfile.tool_setup()
-            if result.setup["open_cmd"][0] in ("UNRAR_TOOL", "UNAR_TOOL"):
-                RAR_SUPPORT["enabled"] = True
-                return
-        except rarfile.RarCannotExec:
-            pass
-        logger.warning(
-            "Install 'Unrar' or 'unar' tool for RAR archive decompression. RAR decompression disabled until installed."
-        )
+            try:
+                shutil.rmtree(temp_dir)
+                logger.info(f"Cleaned up temporary directory: {temp_dir}")
+            except PermissionError as e:
+                logger.error(f"Permission error while deleting {temp_dir}: {e}")
 
 
 # Register exit handler

--- a/surfactant/plugin/manager.py
+++ b/surfactant/plugin/manager.py
@@ -15,13 +15,14 @@ from surfactant.plugin import hookspecs
 def _register_plugins(pm: pluggy.PluginManager) -> None:
     # pylint: disable=import-outside-toplevel
     # don't want all these imports as part of the file-level scope
-    from surfactant.filetypeid import id_extension, id_hex, id_magic
+    from surfactant.filetypeid import id_extension, id_hex, id_magic, id_extractcode
     from surfactant.infoextractors import (
         a_out_file,
         coff_file,
         docker_image,
         elf_file,
         file_decompression,
+        extractcode_file,
         java_file,
         js_file,
         mach_o_file,
@@ -48,6 +49,7 @@ def _register_plugins(pm: pluggy.PluginManager) -> None:
         id_magic,
         id_hex,
         id_extension,
+        id_extractcode,
         a_out_file,
         coff_file,
         docker_image,
@@ -69,6 +71,7 @@ def _register_plugins(pm: pluggy.PluginManager) -> None:
         cytrics_reader,
         native_lib_file,
         file_decompression,
+        extractcode_file,
     )
     for plugin in internal_plugins:
         pm.register(plugin)

--- a/surfactant/plugin/manager.py
+++ b/surfactant/plugin/manager.py
@@ -15,14 +15,14 @@ from surfactant.plugin import hookspecs
 def _register_plugins(pm: pluggy.PluginManager) -> None:
     # pylint: disable=import-outside-toplevel
     # don't want all these imports as part of the file-level scope
-    from surfactant.filetypeid import id_extension, id_hex, id_magic, id_extractcode
+    from surfactant.filetypeid import id_extension, id_extractcode, id_hex, id_magic
     from surfactant.infoextractors import (
         a_out_file,
         coff_file,
         docker_image,
         elf_file,
-        file_decompression,
         extractcode_file,
+        file_decompression,
         java_file,
         js_file,
         mach_o_file,


### PR DESCRIPTION
### Summary

If merged this pull request will add support for a plethora of compression types and archive formats as a best-effort stopgap until we decide to add support for these formats manually (if necessary) to add metadata or version info (e.g. the RPM files that @matthewkelley22 is working on).

### Proposed changes

Removes the .rar file decompression things and replaces it entirely with `extractcode`. Added an additional feature `extractcode-full` that adds 7zip and libarchive binaries as dependencies instead of needing to rely on them existing on the PATH. Ideally, we'd want to have this hook run *last*, but I don't think pluggy supports that. I also injected .wim support to extractcode just to see what Surfactant can do a Windows 11 iso.

### Future Work

Seeing how extractcode identifies binaries, it seems to use [typecode](https://pypi.org/project/typecode), which internally uses the same library that the linux `file` command uses. This may be a better approach to ID-ing files than what we're currently doing with manually checking header bytes (maybe only do this with more specific or lesser-known file types?). Depending on how extractcode behaves, we may want to also look at removing some of the tar/gz/zip/bz file extraction and letting extractcode handle it (unless we have a reason to look at the file metadata directly).
