### PR TITLE
Dnfile PE file crash

### DIFF
--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -304,7 +304,6 @@ def insert_implmap_info(im_info, imp_modules: List[Dict[str, Any]]):
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L36-L39
     # HeapItemString value will be decoded string, or None if there was a UnicodeDecodeError
     dllName = check_attribute_exists(im_info.ImportScope.row.Name)
-
     methodName = check_attribute_exists(im_info.ImportName)
 
     if dllName:

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -225,7 +225,9 @@ def extract_pe_info(filename: str) -> object:
 
 def check_attribute_exists(obj):
     # Checks to see if obj has .value attribute.
-    if hasattr(obj, "value") and obj.value:
+    if hasattr(obj, "value") and obj.value is not None:
+        if isinstance(obj.value, bytes):
+            return obj.value.hex()
         return obj.value
     if hasattr(obj, "raw_data") and obj.raw_data is not None:
         return obj.raw_data.hex()

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -303,23 +303,10 @@ def get_assemblyref_info(asmref_info) -> Dict[str, Any]:
 def insert_implmap_info(im_info, imp_modules: List[Dict[str, Any]]):
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L36-L39
     # HeapItemString value will be decoded string, or None if there was a UnicodeDecodeError
-    if hasattr(im_info.ImportScope.row.Name, "value"):
-        dllName = (
-            im_info.ImportScope.row.Name.value
-            if im_info.ImportScope.row.Name.value
-            else im_info.ImportScope.row.Name.raw_data.hex()
-        )
-    else:
-        dllName = im_info.ImportScope.row.Name
+    dllName = check_attribute_exists(im_info.ImportScope.row.Name)
 
-    if hasattr(im_info.ImportName, "value"):
-        methodName = (
-            im_info.ImportName.value
-            if im_info.ImportName.value
-            else im_info.ImportName.raw_data.hex()
-        )
-    else:
-        methodName = im_info.ImportName
+    methodName = check_attribute_exists(im_info.ImportName)
+
     if dllName:
         for imp_module in imp_modules:
             if imp_module["Name"] == dllName:

--- a/surfactant/infoextractors/pe_file.py
+++ b/surfactant/infoextractors/pe_file.py
@@ -226,20 +226,30 @@ def extract_pe_info(filename: str) -> object:
 def add_core_assembly_info(asm_dict: Dict[str, Any], asm_info):
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L36-L39
     # HeapItemString value will be decoded string, or None if there was a UnicodeDecodeError
-    asm_dict["Name"] = asm_info.Name.value if asm_info.Name.value else asm_info.raw_data.hex()
-    asm_dict["Culture"] = (
-        asm_info.Culture.value if asm_info.Culture.value else asm_info.Culture.raw_data.hex()
-    )
+    if hasattr(asm_info.Name, "value"):
+        asm_dict["Name"] = asm_info.Name.value if asm_info.Name.value else asm_info.raw_data.hex()
+    else:
+        asm_dict["Name"] = asm_info.Name
+
+    if hasattr(asm_info.Culture, "value"):
+        asm_dict["Culture"] = (
+            asm_info.Culture.value if asm_info.Culture.value else asm_info.Culture.raw_data.hex()
+        )
+    else:
+        asm_dict["Culture"] = asm_info.Culture
+
     asm_dict["Version"] = (
         f"{asm_info.MajorVersion}.{asm_info.MinorVersion}.{asm_info.BuildNumber}.{asm_info.RevisionNumber}"
     )
+
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L62-L66
     # HeapItemBinary value is the bytes following the compressed int (indicating the length)
     if asm_info.PublicKey is not None:
-        asm_dict["PublicKey"] = (
+        if hasattr(asm_info.PublicKey, "value"):
             # raw_data attribute of PublicKey includes leading byte with length of data, value attr removes it
-            asm_info.PublicKey.value.hex()
-        )
+            asm_dict["PublicKey"] = asm_info.PublicKey.value.hex()
+        else:
+            asm_dict["PublicKey"] = asm_info.PublicKey.hex()
 
 
 def add_assembly_flags_info(asm_dict, asm_info):
@@ -282,8 +292,11 @@ def get_assemblyref_info(asmref_info) -> Dict[str, Any]:
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L62-L66
     # HeapItemBinary value is the bytes following the compressed int (indicating the length)
     # raw_data attribute has the compressed int indicating length included
-
-    asmref["HashValue"] = asmref_info.HashValue.value.hex()
+    if hasattr(asmref_info.HashValue, "value"):
+        asmref["HashValue"] = asmref_info.HashValue.value.hex()
+    else:
+        # HashValue is bytes
+        asmref["HashValue"] = asmref_info.HashValue.hex()
     add_assembly_flags_info(asmref, asmref_info)
     return asmref
 
@@ -291,14 +304,23 @@ def get_assemblyref_info(asmref_info) -> Dict[str, Any]:
 def insert_implmap_info(im_info, imp_modules: List[Dict[str, Any]]):
     # REFERENCE: https://github.com/malwarefrank/dnfile/blob/096de1b3/src/dnfile/stream.py#L36-L39
     # HeapItemString value will be decoded string, or None if there was a UnicodeDecodeError
-    dllName = (
-        im_info.ImportScope.row.Name.value
-        if im_info.ImportScope.row.Name.value
-        else im_info.ImportScope.row.Name.raw_data.hex()
-    )
-    methodName = (
-        im_info.ImportName.value if im_info.ImportName.value else im_info.ImportName.raw_data.hex()
-    )
+    if hasattr(im_info.ImportScope.row.Name, "value"):
+        dllName = (
+            im_info.ImportScope.row.Name.value
+            if im_info.ImportScope.row.Name.value
+            else im_info.ImportScope.row.Name.raw_data.hex()
+        )
+    else:
+        dllName = im_info.ImportScope.row.Name
+
+    if hasattr(im_info.ImportName, "value"):
+        methodName = (
+            im_info.ImportName.value
+            if im_info.ImportName.value
+            else im_info.ImportName.raw_data.hex()
+        )
+    else:
+        methodName = im_info.ImportName
     if dllName:
         for imp_module in imp_modules:
             if imp_module["Name"] == dllName:


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will stop surfactant from crashing on PE files. In `pefile.py`, dnfile returns strings for .NET assembly metadata fields like `asm_info.Name` and `asm_info.Culture`. The script previously assumes these fields are objects with a `.value` attribute, but they're usually just strings or bytes.

https://github.com/malwarefrank/dnfile/blob/master/src/dnfile/mdtable.py
Reference above shows `Name` and `Culture` metadata fields are strings and `PublicKey` and `HashValue` fields are bytes.

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
This PR updates the code to handle both objects with a `.value` attribute and plain strings or bytes, preventing crashes when parsing PE files.