### PR TITLE
refactor!: rename specimen config to specimen context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or decompilation.
 
 For ease of use, we recommend using [pipx](https://github.com/pypa/pipx) since it transparently handles creating and using Python virtual environments, which helps avoid dependency conflicts with other installed Python apps. Install `pipx` by following [their installation instructions](https://github.com/pypa/pipx#install-pipx).
 
-1. Install Surfactant using `pipx install` (with python >= 3.8)
+1. Install Surfactant using `pipx install` (with python >= 3.9)
 
 ```bash
 pipx install surfactant
@@ -46,7 +46,7 @@ pipx inject surfactant git+https://github.com/LLNL/Surfactant#subdirectory=plugi
 
 If for some reason manually managing virtual environments is desired, the following steps can be used instead:
 
-1. Create a virtual environment with python >= 3.8 and activate it [Optional, but highly recommended over a global install]
+1. Create a virtual environment with python >= 3.9 and activate it [Optional, but highly recommended over a global install]
 
 ```bash
 python -m venv venv
@@ -67,7 +67,7 @@ pip install git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhas
 
 ### For Developers:
 
-1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+1. Create a virtual environment with python >= 3.9 [Optional, but recommended]
 
 ```bash
 python -m venv venv
@@ -103,10 +103,10 @@ pip install -e plugins/fuzzyhashes
 Surfactant supports several subcommands that can be shown using `surfactant --help`. The main one for creating an SBOM is the `generate` subcommand, which takes the following arguments:
 
 ```bash
-surfactant generate [OPTIONS] SPECIMEN_CONFIG SBOM_OUTFILE [INPUT_SBOM]
+surfactant generate [OPTIONS] SPECIMEN_CONTEXT SBOM_OUTFILE [INPUT_SBOM]
 ```
 
-The two required arguments are a specimen configuration, and the output SBOM file name. For a simple case of generating an SBOM for a single directory or file, it is enough to just use the path to the directory or file for the specimen configuration. For example, the following command will generate an SBOM file called `output.json` with software entries for all files found in the folder `mysoftware`:
+The two required arguments are a specimen context, and the output SBOM file name. For a simple case of generating an SBOM for a single directory or file, it is enough to just use the path to the directory or file for the specimen configuration. For example, the following command will generate an SBOM file called `output.json` with software entries for all files found in the folder `mysoftware`:
 
 ```bash
 surfactant generate /usr/local/mysoftware output.json
@@ -114,9 +114,9 @@ surfactant generate /usr/local/mysoftware output.json
 
 In the generated SBOM, there will be software entries for each file. The install paths captured will say where individual files are located within `/usr/local/mysoftware` -- if instead a relative path had been given such as `surfactant generate local/mysoftware output.json`, all of the install paths for files would appear to be under the relative path `local/mysoftware` instead of an absolute path.
 
-For more control over the options used to create software entries and relationships, or for capturing information from multiple directories, see the following section on how to write a [Surfactant specimen config file](#build-configuration-file-for-sample). This configuration file is a JSON file can then be given to Surfactant for the `SPECIMEN_CONFIG` argument.
+For more control over the options used to create software entries and relationships, or for capturing information from multiple directories, see the following section on how to write a [Surfactant specimen context file](#build-context-file-for-sample). This context file is a JSON file can then be given to Surfactant for the `SPECIMEN_CONTEXT` argument.
 
-NOTE: When using a Surfactant speciment configuration file, it is recommended that it end in a `.json` file extension; otherwise, you'll have to use a special prefix for the `SPECIMEN_CONFIG` argument to tell Surfactant that it should interpret the given file that doesn't end in `.json` as a specimen configuration file rather than to generate an SBOM that only contains details on that one file.
+NOTE: When using a Surfactant speciment context JSON file, it is recommended that it end in a `.json` file extension; otherwise, you'll have to use a special prefix (`context:`) for the `SPECIMEN_CONTEXT` argument to tell Surfactant that it should interpret the given file that doesn't end in `.json` as a specimen configuration file rather than to generate an SBOM that only contains details on that one file.
 
 ## Settings
 
@@ -162,11 +162,11 @@ recorded_institution = "LLNL"
 
 ### Identify sample file
 
-In order to test out surfactant, you will need a sample file/folder. If you don't have one on hand, you can download and use the portable .zip file from <https://github.com/ShareX/ShareX/releases> or the Linux .tar.gz file from <https://github.com/GMLC-TDC/HELICS/releases>.
+In order to test out surfactant, you will need a sample file/folder to generate an SBOM for. If you don't have one on hand, you can download and use the portable .zip file from <https://github.com/ShareX/ShareX/releases> or the Linux .tar.gz file from <https://github.com/GMLC-TDC/HELICS/releases>.
 
-### Build configuration file for sample
+### Build context file for sample
 
-A configuration file for a sample contains the information about the sample to gather information from. Example JSON sample configuration files can be found in the examples folder of this repository.
+A JSON context file for a sample contains the information about the sample to gather information from. Example JSON context files can be found in the examples folder of this repository.
 
 - **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the files or folders to gather information on. Note that even on Windows, Unix style `/` directory separators should be used in paths.
 - **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the files or folders in `extractPaths` were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various `extractPaths`.
@@ -176,27 +176,17 @@ A configuration file for a sample contains the information about the sample to g
 - **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `omitUnrecognizedTypes` and `includeFileExts` are set, the specified extensions in `includeFileExts` will still be included.
 - **skipProcessingArchive**: (optional) Skip processing the given archive file with info extractors. Software entry for the archive file will only contain basic information such as hashes. Default setting is False.
 
-#### Create config command
+#### Create context file using the TUI
 
-A basic configuration file can be easily built using the `create-config` command. This will take a path as a command line argument and will save a file with the default name of the end directory passed to it as a json file. i.e., `/home/user/Desktop/myfolder` will create `myfolder.json`.
+The Surfactant TUI has a "Context" tab that can be used to create a context file. Launch the TUI with `surfactant tui` and then navigate to the TUI tab to get to the editor for creating and modifying context files. This is the easiest way for new users to create a context file from scratch. The following sections will walkthrough what the context files look like, and the resulting SBOM with different options set in the context file entries.
 
-```bash
-$  surfactant create-config [INPUT_PATH]
-```
-
-The --output flag can be used to specify the configuration output name. The --install-prefix can be used to specify the install prefix, the default is '/'.
-
-```bash
-$  surfactant create-config [INPUT_PATH] --output new_output.json --install-prefix 'C:/'
-```
-
-#### Example configuration file
+#### Example context file
 
 Let's say you have a .tar.gz file that you want to run surfactant on. For this example, we will be using the HELICS release .tar.gz example. In this scenario, the absolute path for this file is `/home/samples/helics.tar.gz`. Upon extracting this file, we get a helics folder with 4 sub-folders: bin, include, lib64, and share.
 
-##### Example 1: Simple Configuration File
+##### Example 1: Simple Context File
 
-If we want to include only the folders that contain binary files to analyze, our most basic configuration would be:
+If we want to include only the folders that contain binary files to analyze, our most basic context file would be:
 
 ```json
 [
@@ -234,9 +224,9 @@ The resulting SBOM would be structured like this:
 }
 ```
 
-##### Example 2: Detailed Configuration File
+##### Example 2: Detailed Context File
 
-A more detailed configuration file might look like the example below. The resulting SBOM would have a software entry for the helics.tar.gz with a "Contains" relationship to all binaries found to in the extractPaths. Providing the install prefix of `/` and an extractPaths as `/home/samples/helics` will allow to surfactant correctly assign the install paths in the SBOM for binaries in the subfolders as `/bin` and `/lib64`.
+A more detailed context file might look like the example below. The resulting SBOM would have a software entry for the helics.tar.gz with a "Contains" relationship to all binaries found to in the extractPaths. Providing the install prefix of `/` and an extractPaths as `/home/samples/helics` will allow to surfactant correctly assign the install paths in the SBOM for binaries in the subfolders as `/bin` and `/lib64`.
 
 ```json
 [
@@ -294,7 +284,7 @@ The resulting SBOM would be structured like this:
 
 ##### Example 3: Adding Related Binaries
 
-If our sample helics tar.gz file came with a related tar.gz file to install a plugin extension module (extracted into a helics_plugin folder that contains bin and lib64 subfolders), we could add that into the configuration file as well:
+If our sample helics tar.gz file came with a related tar.gz file to install a plugin extension module (extracted into a helics_plugin folder that contains bin and lib64 subfolders), we could add that information to the context file as well:
 
 ```json
 [
@@ -393,15 +383,23 @@ The resulting SBOM would be structured like this:
 }
 ```
 
-NOTE: These examples have been simplified to show differences in output based on configuration.
+NOTE: These examples have been simplified to show differences in output based on the context file provided.
 
-### Run surfactant
+### Run Surfactant
+
+The Surfactant TUI for generating and merging SBOMs, as well as working with specimen context files, can be launched with the following command:
 
 ```bash
-$  surfactant generate [OPTIONS] SPECIMEN_CONFIG SBOM_OUTFILE [INPUT_SBOM]
+$  surfactant tui
 ```
 
-**SPECIMEN_CONFIG**: (required) the config file created earlier that contains the information on specimens to include in an SBOM, or the path to a specific file/directory to generate an SBOM for with some implied default configuration options\
+While the TUI provides access to most of the options for generating SBOMs, there are times when it may be necessary to run the generate command directly to access certain extra command line options, or in environments where a TUI can't be used:
+
+```bash
+$  surfactant generate [OPTIONS] SPECIMEN_CONTEXT SBOM_OUTFILE [INPUT_SBOM]
+```
+
+**SPECIMEN_CONTEXT**: (required) the context file created earlier that contains the information on specimens to include in an SBOM, or the path to a specific file/directory to generate an SBOM for with some implied default context options\
 **SBOM OUTPUT**: (required) the desired name of the output file\
 **INPUT_SBOM**: (optional) a base sbom, should be used with care as relationships could be messed up when files are installed on different systems\
 **--skip_gather**: (optional) skips the gathering of information on files and adding software entires\
@@ -436,7 +434,7 @@ A folder containing multiple separate SBOM JSON files can be combined using merg
 
 `ls -d ~/Folder_With_SBOMs/Surfactant-* | xargs -d '\n' surfactant merge --config_file=merge_config.json --sbom_outfile combined_sbom.json`
 
-If the config file option is given, a top-level system entry will be created that all other software entries are tied to (directly or indirectly based on other relationships). Specifying an empty UUID will make a random UUID get generated for the new system entry, otherwise it will use the one provided.
+If the merge config file option is given, a top-level system entry will be created that all other software entries are tied to (directly or indirectly based on other relationships). Specifying an empty UUID will make a random UUID get generated for the new system entry, otherwise it will use the one provided.
 
 Details on the merge command can be found in the docs page [here](./docs/basic_usage.md#merging-sboms).
 

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -9,11 +9,24 @@ In order to test out surfactant, you will need a sample file/folder. If you don'
 
 ## Running Surfactant
 
+Most of the functionality for the generate and merge subcommands can be accessed via the Surfactant TUI, which can be launched using the following command:
+
 ```bash
-$  surfactant generate [OPTIONS] SPECIMEN_CONFIG SBOM_OUTFILE [INPUT_SBOM]
+$  surfactant tui
 ```
 
-**SPECIMEN_CONFIG**: (required) the config file created earlier that contains the information on specimens to include in an SBOM, or the path to a specific file/directory to generate an SBOM for with some implied default configuration options\
+The TUI also provides a convenient interface for creating a specimen context JSON file for more complex SBOM generation use cases, and will also soon provide options for changing Surfactant configuration settings and managing plugins.
+
+While the TUI provides access to most of the options for generating SBOMs, there are times when it may be necessary to run the generate command directly to access certain extra command line options, or in environments where a TUI can't be used.
+
+
+## Generating SBOMs
+
+```bash
+$  surfactant generate [OPTIONS] SPECIMEN_CONTEXT SBOM_OUTFILE [INPUT_SBOM]
+```
+
+**SPECIMEN_CONTEXT**: (required) the context file created earlier that contains the information on specimens to include in an SBOM, or the path to a specific file/directory to generate an SBOM for with some implied default context options\
 **SBOM OUTPUT**: (required) the desired name of the output file\
 **INPUT_SBOM**: (optional) a base sbom, should be used with care as relationships could be messed up when files are installed on different systems\
 **--skip_gather**: (optional) skips the gathering of information on files and adding software entires\
@@ -22,9 +35,7 @@ $  surfactant generate [OPTIONS] SPECIMEN_CONFIG SBOM_OUTFILE [INPUT_SBOM]
 **--recorded_institution**: (optional) the name of the institution collecting the SBOM data (default: LLNL)\
 **--output_format**: (optional) changes the output format for the SBOM (given as full module name of a surfactant plugin implementing the `write_sbom` hook)\
 **--input_format**: (optional) specifies the format of the input SBOM if one is being used (default: cytrics) (given as full module name of a surfactant plugin implementing the `read_sbom` hook)\
-**--help**: (optional) show the help message and exit\
-**--omit_unrecognized_types**: (optional) Omit files with unrecognized types from the generated SBOM
-
+**--help**: (optional) show the help message and exit
 
 
 ## Merging SBOMs

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -1,7 +1,7 @@
 # Configuration Files
 
 There are several files for configuring different aspects of Surfactant functionality based on the subcommand used.
-This page currently describes specimen configuration files, and the Surfactant settings configuration file. The specimen configuration file is used to generate an SBOM for a particular software/firmware sample, and will be the most frequently written by users. The Surfactant settings configuration file is used to turn on and off various Surfactant features, including settings for controlling functionality in Surfactant plugins.
+This page currently describes specimen context files, and the Surfactant settings configuration file. The specimen context file is used to generate an SBOM for a particular software/firmware sample, and will be the one users are most likely to have to create and edit. The Surfactant settings configuration file is used to turn on and off various Surfactant features, including settings for controlling functionality in Surfactant plugins.
 
 ## Settings Configuration File
 
@@ -43,9 +43,11 @@ The file itself is a TOML file, and for the previously mentioned example plugin 
 recorded_institution = "LLNL"
 ```
 
-## Specimen Configuration File
+## Specimen Context File
 
-A specimen configuration file contains the information about the sample to gather information from. Example JSON specimen configuration files can be found in the examples folder of this repository.
+A specimen context file contains the information about the sample to gather information from. Example JSON specimen context files can be found in the examples folder of this repository.
+
+The `Context` tab in the Surfactant TUI (launched with the `surfactant tui` command) provides an interface for creating and modifying specimen context files. Most of the options described can be set using the TUI, however there may be less frequently used options that require modifying the context file by hand.
 
 - **extractPaths**: (required) the absolute path or relative path from location of current working directory that `surfactant` is being run from to the files or folders to gather information on. Note that even on Windows, Unix style `/` directory separators should be used in paths.
 - **archive**: (optional) the full path, including file name, of the zip, exe installer, or other archive file that the files or folders in `extractPaths` were extracted from. This is used to collect metadata about the overall sample and will be added as a "Contains" relationship to all software entries found in the various `extractPaths`.
@@ -55,13 +57,13 @@ A specimen configuration file contains the information about the sample to gathe
 - **excludeFileExts**: (optional) A list of file extensions to exclude, even if recognized by Surfactant. Note that if both `omitUnrecognizedTypes` and `includeFileExts` are set, the specified extensions in `includeFileExts` will still be included.
 - **skipProcessingArchive**: (optional) Skip processing the given archive file with info extractors. Software entry for the archive file will still appear in the SBOM with basic info such as hashes, but no information extraction plugins will run to pull out extra file type specific info. Default setting is False.
 
-## Example configuration files
+## Example context files
 
 Lets say you have a .tar.gz file that you want to run surfactant on. For this example, we will be using the HELICS release .tar.gz example. In this scenario, the absolute path for this file is /home/samples/helics.tar.gz. Upon extracting this file, we get a helics folder with 4 sub-folders: bin, include, lib64, and share.
 
-### Example 1: Simple Configuration File
+### Example 1: Simple Context File
 
-If we want to include only the folders that contain binary files to analyze, our most basic configuration would be:
+If we want to include only the folders that contain binary files to analyze, our most basic context file would be:
 
 ```json
 [
@@ -99,9 +101,9 @@ The resulting SBOM would be structured like this:
 }
 ```
 
-### Example 2: Detailed Configuration File
+### Example 2: Detailed Context File
 
-A more detailed configuration file might look like the example below. The resulting SBOM would have a software entry for the helics.tar.gz with a "Contains" relationship to all binaries found to in the extractPaths. Providing the install prefix of `/` and an extractPaths as `/home/samples/helics` will allow to surfactant correctly assign the install paths in the SBOM for binaries in the subfolders as `/bin` and `/lib64`.
+A more detailed context file might look like the example below. The resulting SBOM would have a software entry for the helics.tar.gz with a "Contains" relationship to all binaries found to in the extractPaths. Providing the install prefix of `/` and an extractPaths as `/home/samples/helics` will allow to surfactant correctly assign the install paths in the SBOM for binaries in the subfolders as `/bin` and `/lib64`.
 
 ```json
 [
@@ -159,7 +161,7 @@ The resulting SBOM would be structured like this:
 
 ### Example 3: Adding Related Binaries
 
-If our sample helics tar.gz file came with a related tar.gz file to install a plugin extension module (extracted into a helics_plugin folder that contains bin and lib64 subfolders), we could add that into the configuration file as well:
+If our sample helics tar.gz file came with a related tar.gz file to install a plugin extension module (extracted into a helics_plugin folder that contains bin and lib64 subfolders), we could add that into the context file as well:
 
 ```json
 [
@@ -258,4 +260,4 @@ The resulting SBOM would be structured like this:
 }
 ```
 
-NOTE: These examples have been simplified to show differences in output based on configuration.
+NOTE: These examples have been simplified to show differences in output based on the context file provided.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,7 @@
 
 ## System Prerequisites
 
-Surfactant requires Python 3.8 or newer. Tests are regularly run on Linux, macOS,
+Surfactant requires Python 3.9 or newer. Tests are regularly run on Linux, macOS,
 and Windows, though it should also work on other operating systems such as FreeBSD.
 
 ## Installation
@@ -11,7 +11,7 @@ and Windows, though it should also work on other operating systems such as FreeB
 
 For ease of use, we recommend using [pipx](https://github.com/pypa/pipx) since it transparently handles creating and using Python virtual environments, which helps avoid dependency conflicts with other installed Python apps. Install `pipx` by following [their installation instructions](https://github.com/pypa/pipx#install-pipx).
 
-1. Install Surfactant using `pipx install` (with python >= 3.8)
+1. Install Surfactant using `pipx install` (with python >= 3.9)
 
 ```bash
 pipx install surfactant
@@ -27,7 +27,7 @@ pipx inject surfactant git+https://github.com/LLNL/Surfactant#subdirectory=plugi
 
 If for some reason manually managing virtual environments is desired, the following steps can be used instead:
 
-1. Create a virtual environment with python >= 3.8 and activate it [Optional, but highly recommended over a global install]
+1. Create a virtual environment with python >= 3.9 and activate it [Optional, but highly recommended over a global install]
 
 ```bash
 python -m venv venv
@@ -48,7 +48,7 @@ pip install git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhas
 
 ### For Developers:
 
-1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+1. Create a virtual environment with python >= 3.9 [Optional, but recommended]
 
 ```bash
 python -m venv venv
@@ -76,7 +76,10 @@ pip install -e ".[test,dev]"
 `pip install` with the `-e` or `--editable` option can also be used to install Surfactant plugins for development.
 
 ## Generating an SBOM
-To create an SBOM, run the `surfactant generate` subcommand. For more details on the options it takes, please refer to this page on [basic usage](basic_usage.md). For more information on writing Surfactant configuration files for software specimens, see the documentation on how to build a [specimen configuration file](configuration_files.md#specimen-configuration-file).
+
+The most straightforward method to start is using the `surfactant tui` subcommand to start the TUI, then use the `Generate` tab to generate an SBOM, and the `Context` tab to create and modify specimen context files. The rest of this section will assume that the command line `surfactant generate` subcommand is being used, however the same general concepts such as the specimen context can still apply when using the TUI.
+
+To generate an SBOM without the TUI, run the `surfactant generate` subcommand. For more details on the options it takes, please refer to this page on [basic usage](basic_usage.md). For more information on writing Surfactant context files for software specimens, see the documentation on how to build a [specimen context file](configuration_files.md#specimen-context-file).
 
 The following diagram gives a high-level overview of what Surfactant does. The [internal implementation overview](internals_overview.md) page gives more detail about how Surfactant works internally.
 
@@ -90,21 +93,21 @@ surfactant generate "C:/Program Files/Adobe/Acrobat Reader" acrobat_reader_sbom.
 
 This command will generate an output SBOM file named `acrobat_reader_sbom.json` for all files in `C:/Program Files/Adobe/Acrobat Reader`, with install paths for files in the SBOM that show them as being under `C:/Program Files/Adobe/Acrobat Reader`. Alternatively, running Surfactant from the `C:/Program Files/Adobe` folder with the command `surfactant generate "Acrobat Reader" acrobat_reader_sbom.json` would result in the install paths in the SBOM showing the files as being under the relative path `Acrobat Reader/`.
 
-If the path is to a single file an SBOM will be generated for that single file, unless its name ends in a `.json` extension (or the very rare case of the path being given to Surfactant beginning with one of 3 special prefixes: `config:`, `file:`, and `dir:`).
+If the path is to a single file an SBOM will be generated for that single file, unless its name ends in a `.json` extension (or the very rare case of the path being given to Surfactant beginning with one of 3 special prefixes: `context:`, `file:`, and `dir:`).
 
-If an SBOM is being generated that requires more fine-grained control over various options such as the install prefix, or for capturing information on multiple locations, then Surfactant should be given a path to a [specimen configuration file](configuration_files.md#specimen-configuration-file). It is strongly recommended to always include a `.json` file extension as part of the file name.
+If an SBOM is being generated that requires more fine-grained control over various options such as the install prefix, or for capturing information on multiple locations, then Surfactant should be given a path to a [specimen context file](configuration_files.md#specimen-context-file). It is strongly recommended to always include a `.json` file extension as part of the file name.
 
-### Special Specimen Config Argument Prefixes
+### Special Specimen Context Argument Prefixes
 
-For the specimen config command line argument, the path to a file with a `.json` extension is always treated as a specimen configuration file, and a path to a file without a `.json` file extension is treated as being for generating an SBOM with just that single file. To override this behavior, the specimen configuration argument to `surfactant generate` recognizes the special prefixes `config:`, `file:`, and `dir:`. For example, `surfactant generate file:home/abc.json` would tell Surfactant to generate an SBOM with a single entry in it, for the file called `abc.json` in the `home` directory (without the `file:` prefix, `home/abc.json` would be interpreted as a specimen configuration file).
+For the specimen context command line argument, the path to a file with a `.json` extension is always treated as a specimen context file, and a path to a file without a `.json` file extension is treated as being for generating an SBOM with just that single file. To override this behavior, the specimen context argument to `surfactant generate` recognizes the special prefixes `context:`, `file:`, and `dir:`. For example, `surfactant generate file:home/abc.json` would tell Surfactant to generate an SBOM with a single entry in it, for the file called `abc.json` in the `home` directory (without the `file:` prefix, `home/abc.json` would be interpreted as a specimen context file).
 
-Similarly, a `config:` prefix forces Surfactant to interpret the given file path as a specimen configuration file regardless of if the file name is missing a `.json` extension.
+Similarly, a `context:` prefix forces Surfactant to interpret the given file path as a specimen context file regardless of if the file name is missing a `.json` extension.
 
-A file or directory name that starts with one of these special prefixes could cause problems, however these cases should be extremely rare and can always be solved by creating a specimen configuration file (which since it is user created, can be given a file name that avoids issues). However, a special prefix could also be used to solve the issue. For example with a directory named `config:myapp`, running `surfactant generate config:myapp` will look for a specimen configuration file called `myapp`. To resolve this, the `dir:` prefix could be added to essentially tell Surfactant "this directory is actually named config:myapp". Running `surfactant generate dir:config:myapp` would then generate an SBOM for everyting in a directory called `config:myapp`.
+A file or directory name that starts with one of these special prefixes could cause problems, however these cases should be extremely rare and can always be solved by creating a specimen context file (which since it is user created, can be given a file name that avoids issues). However, a special prefix could also be used to solve the issue. For example with a directory named `context:myapp`, running `surfactant generate context:myapp` will look for a specimen context file called `myapp`. To resolve this, the `dir:` prefix could be added to essentially tell Surfactant "this directory is actually named context:myapp". Running `surfactant generate dir:context:myapp` would then generate an SBOM for everyting in a directory called `context:myapp`.
 
-NOTE: As long as the directory or file name that starts with the special prefix isn't the first thing in the argument, adding a special prefix shouldn't be necessary. For example, running `surfactant generate abc/config:myapp` or `surfactant generate /etc/config:myapp` to create an SBOM from a directory or file called `config:myapp` should work without issues since the specimen config argument doesn't start with one of the special prefixes.
+NOTE: As long as the directory or file name that starts with the special prefix isn't the first thing in the argument, adding a special prefix shouldn't be necessary. For example, running `surfactant generate abc/context:myapp` or `surfactant generate /etc/context:myapp` to create an SBOM from a directory or file called `context:myapp` should work without issues since the specimen context argument doesn't start with one of the special prefixes.
 
-Surfactant specimen configuration file should never be given a name that starts with one of these special prefixes, and should always end in a `.json` file extension.
+Surfactant specimen context files should never be given a name that starts with one of these special prefixes, and should always end in a `.json` file extension.
 
 ## Understanding the SBOM Output
 

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -113,8 +113,8 @@ def generate_sbom_string(
     if install_prefix is None:
         install_prefix = folder_path.as_posix() + "/"
 
-    # Create specimen config for the single folder
-    specimen_config = [{"extractPaths": [folder_path.as_posix()], "installPrefix": install_prefix}]
+    # Create specimen context for the single folder
+    specimen_context = [{"extractPaths": [folder_path.as_posix()], "installPrefix": install_prefix}]
 
     # Create an in-memory file-like object to capture output
     output_buffer = io.StringIO()
@@ -126,7 +126,7 @@ def generate_sbom_string(
                 # Use Click's invoke to call the command with the context
                 ctx.invoke(
                     sbom,
-                    specimen_config=specimen_config,
+                    specimen_context=specimen_context,
                     sbom_outfile=output_buffer,
                 )
             except Exception as e:

--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -12,7 +12,7 @@ import click
 from loguru import logger
 
 from surfactant import ContextEntry
-from surfactant.cmd.internal.generate_utils import SpecimenConfigParamType
+from surfactant.cmd.internal.generate_utils import SpecimenContextParamType
 from surfactant.configmanager import ConfigManager
 from surfactant.fileinfo import sha256sum
 from surfactant.plugin.manager import call_init_hooks, find_io_plugin, get_plugin_manager
@@ -195,9 +195,9 @@ def get_default_from_config(option: str, fallback: Optional[Any] = None) -> Any:
 
 @click.command("generate")
 @click.argument(
-    "specimen_config",
-    envvar="SPECIMEN_CONFIG",
-    type=SpecimenConfigParamType(),
+    "specimen_context",
+    envvar="SPECIMEN_CONTEXT",
+    type=SpecimenContextParamType(),
     required=True,
 )
 @click.argument("sbom_outfile", envvar="SBOM_OUTPUT", type=click.File("w"), required=True)
@@ -267,7 +267,7 @@ def get_default_from_config(option: str, fallback: Optional[Any] = None) -> Any:
 # Disable positional argument linter check -- could make keyword-only, but then defaults need to be set
 # pylint: disable-next=too-many-positional-arguments
 def sbom(
-    specimen_config: list,
+    specimen_context: list,
     sbom_outfile: click.File,
     input_sbom: click.File,
     skip_gather: bool,
@@ -278,7 +278,7 @@ def sbom(
     input_format: str,
     omit_unrecognized_types: bool,
 ):
-    """Generate a sbom configured in CONFIG_FILE and output to SBOM_OUTPUT.
+    """Generate a sbom based on SPECIMEN_CONTEXT and output to SBOM_OUTPUT.
 
     An optional INPUT_SBOM can be supplied to use as a base for subsequent operations.
     """
@@ -292,7 +292,7 @@ def sbom(
 
     contextQ: queue.Queue[ContextEntry] = queue.Queue()
 
-    for cfg_entry in specimen_config:
+    for cfg_entry in specimen_context:
         contextQ.put(ContextEntry(**cfg_entry))
 
     # define the new_sbom variable type

--- a/surfactant/cmd/internal/generate_utils.py
+++ b/surfactant/cmd/internal/generate_utils.py
@@ -10,27 +10,27 @@ import click
 
 
 # pylint: disable=too-few-public-methods
-class SpecimenConfigParamType(click.Path):
+class SpecimenContextParamType(click.Path):
     """
-    A custom Click parameter type for handling configuration paths.
+    A custom Click parameter type for handling specimen context paths.
     This class extends `click.Path` to provide additional functionality for
-    handling different types of configuration paths, including files, directories,
-    and JSON configuration files.
+    handling different types of context paths, including files, directories,
+    and JSON context configuration files.
     Attributes:
-        name (str): The name of the parameter type, set to "config".
+        name (str): The name of the parameter type, set to "context".
     Methods:
         convert(value, param, ctx):
             Converts the input value based on its prefix and returns the appropriate
-            configuration data. Supports the following prefixes:
+            context data. Supports the following prefixes:
             - "file:" for file paths
             - "dir:" for directory paths
-            - "config:" for JSON configuration files
+            - "context:" for JSON context configuration files
             If no prefix is provided, it attempts to determine if the value is a file
             and loads it as JSON if possible. Otherwise, it treats the value as a
             directory path.
     """
 
-    name = "specimen_config"
+    name = "specimen_context"
 
     @staticmethod
     def _get_param_type(filename: str):
@@ -39,10 +39,10 @@ class SpecimenConfigParamType(click.Path):
             filename (str): The filename string to analyze, optionally with a type prefix
         Returns:
             tuple: A 3-tuple containing:
-                - str: The parameter type ('FILE', 'DIR', 'CONFIG', or '' for default)
+                - str: The parameter type ('FILE', 'DIR', 'CONTEXT', or '' for default)
                 - Path: The filepath as a Path object
                 - Path or None: The install prefix path (for files), directory path (for dirs),
-                  or None (for config or default)
+                  or None (for context or default)
         """
 
         if filename.startswith("file:"):
@@ -51,9 +51,9 @@ class SpecimenConfigParamType(click.Path):
         if filename.startswith("dir:"):
             filepath = pathlib.Path(filename[4:])
             return "DIR", filepath, filepath
-        if filename.startswith("config:"):
+        if filename.startswith("context:"):
             filepath = pathlib.Path(filename[7:])
-            return "CONFIG", filepath, None
+            return "CONTEXT", filepath, None
         return "", pathlib.Path(filename), None
 
     def convert(self, value, param, ctx):
@@ -71,11 +71,11 @@ class SpecimenConfigParamType(click.Path):
 
         # no explicit type given, use heuristics to determine correct type
         if not param_type:
-            # if it's a file (that ends in .json) then treat it as a CONFIG file
+            # if it's a file (that ends in .json) then treat it as a CONTEXT file
             # if it's not a file then probably a directory (or something odd...)
             if filepath.is_file():
                 if filepath.suffix.lower() == ".json":
-                    param_type = "CONFIG"
+                    param_type = "CONTEXT"
                 else:
                     param_type = "FILE"
                     installprefix = filepath.parent
@@ -89,30 +89,30 @@ class SpecimenConfigParamType(click.Path):
                 installprefix = ""
             else:
                 installprefix = installprefix.as_posix()
-            # emulate a configuration file with the given path
-            config = [{"extractPaths": [filepath.as_posix()], "installPrefix": installprefix}]
-        elif param_type in ("CONFIG"):
+            # emulate a context configuration file with the given path
+            context = [{"extractPaths": [filepath.as_posix()], "installPrefix": installprefix}]
+        elif param_type in ("CONTEXT"):
             with click.open_file(filepath) as f:
                 try:
-                    config = json.load(f)
+                    context = json.load(f)
                 except json.decoder.JSONDecodeError as err:
                     self.fail(
-                        f"{filepath.as_posix()!r} config file contains invalid JSON", param, ctx
+                        f"{filepath.as_posix()!r} context file contains invalid JSON", param, ctx
                     )
 
-                for entry in config:
+                for entry in context:
                     if "extractPaths" not in entry:
-                        self.fail(f"missing extractPaths in config file entry: {entry}")
+                        self.fail(f"missing extractPaths in context file entry: {entry}")
                     extract_path = entry["extractPaths"]
                     for pth in extract_path:
                         extract_path_convert = pathlib.Path(pth)
                         if not extract_path_convert.exists():
-                            self.fail(f"invalid extract path in config file: {pth}", param, ctx)
+                            self.fail(f"invalid extract path in context file: {pth}", param, ctx)
                     if "archive" in entry:
                         archive_path = pathlib.Path(entry["archive"])
                         if not archive_path.exists():
-                            self.fail(f"invalid archive path in config file: {entry['archive']}")
+                            self.fail(f"invalid archive path in context file: {entry['archive']}")
         else:
-            self.fail(f"{value!r} is not a valid specimen config type", param, ctx)
+            self.fail(f"{value!r} is not a valid specimen context type", param, ctx)
 
-        return config
+        return context

--- a/surfactant/cmd/tui.py
+++ b/surfactant/cmd/tui.py
@@ -130,7 +130,7 @@ class FileInput(textual.widgets.Static):
 class GenerateTab(textual.widgets.Static):
     def __init__(self):
         super().__init__()
-        self.file_input = FileInput("Input file:", True, None)
+        self.specimen_context = FileInput("Specimen context:", True, None)
         self.output_name = textual.widgets.Input(placeholder="Output Filename")
         self.output_dir = FileInput("Output directory:", True, self.output_name)
         self.input_sbom = FileInput("Input SBOM:", False, None)
@@ -144,7 +144,7 @@ class GenerateTab(textual.widgets.Static):
         )
 
     def compose(self) -> textual.app.ComposeResult:
-        yield self.file_input
+        yield self.specimen_context
         yield self.output_dir
         yield textual.containers.HorizontalGroup(
             textual.widgets.Label("Output Filename: "), self.output_name
@@ -168,7 +168,7 @@ class GenerateTab(textual.widgets.Static):
 
     @textual.on(textual.widgets.Button.Pressed, "#run")
     def handle_run(self) -> None:
-        if len(self.file_input.input_path) == 0:
+        if len(self.specimen_context.input_path) == 0:
             self.app.notify("No input file selected")
             return
         if len(self.output_dir.input_path) == 0:
@@ -179,7 +179,7 @@ class GenerateTab(textual.widgets.Static):
             return
         with self.app.suspend():
             args = [
-                self.file_input.input_path,
+                self.specimen_context.input_path,
                 f"{self.output_dir.input_path}/{self.output_name.value}",
             ]
             if len(self.input_sbom.input_path) > 0:
@@ -231,8 +231,10 @@ class InputPathsHolder(textual.widgets.Static):
     def compose(self) -> textual.app.ComposeResult:
         for m_path in self.input_paths:
             if m_path.active:
-                yield m_path
-        yield textual.widgets.Button("+", id="add_input_path")
+                yield textual.containers.HorizontalGroup(textual.widgets.Label("   "), m_path)
+        yield textual.containers.HorizontalGroup(
+            textual.widgets.Label("   "), textual.widgets.Button("+", id="add_input_path")
+        )
 
     @textual.on(textual.widgets.Button.Pressed, "#add_input_path")
     def add_input_path(self):
@@ -311,7 +313,7 @@ class MergeTab(textual.widgets.Static):
         self.app.refresh()
 
 
-class ConfigEntry(textual.widgets.Static):
+class ContextEntry(textual.widgets.Static):
     def __init__(self, header_num):
         super().__init__()
         self.active = True
@@ -345,18 +347,18 @@ class ConfigEntry(textual.widgets.Static):
         )
 
 
-class ConfigTab(textual.widgets.Static):
+class ContextTab(textual.widgets.Static):
     def __init__(self):
         super().__init__()
-        self.config_name = textual.widgets.Input(placeholder="Config filename")
-        self.config_input = FileInput("Config directory:", True, self.config_name)
-        self.config_entries: list[ConfigEntry] = []
-        self.config_number = 1
+        self.context_name = textual.widgets.Input(placeholder="Context filename")
+        self.context_input = FileInput("Context file directory:", True, self.context_name)
+        self.context_entries: list[ContextEntry] = []
+        self.context_count = 1
 
     def compose(self) -> textual.app.ComposeResult:
-        yield self.config_input
+        yield self.context_input
         yield textual.containers.HorizontalGroup(
-            textual.widgets.Label("Config filename: "), self.config_name
+            textual.widgets.Label("Context filename: "), self.context_name
         )
         yield textual.containers.HorizontalGroup(
             textual.widgets.Button("Save", id="save"),
@@ -364,19 +366,19 @@ class ConfigTab(textual.widgets.Static):
             textual.widgets.Button("Load", id="load"),
         )
         yield textual.widgets.Rule()
-        yield from self.config_entries
-        yield textual.widgets.Button("+", id="add_config_entry")
+        yield from self.context_entries
+        yield textual.widgets.Button("+", id="add_context_entry")
 
-    @textual.on(textual.widgets.Button.Pressed, "#add_config_entry")
-    def add_config_entry(self):
-        self.config_entries.append(ConfigEntry(self.config_number))
-        self.mount(self.config_entries[-1], before="#add_config_entry")
-        self.config_number += 1
+    @textual.on(textual.widgets.Button.Pressed, "#add_context_entry")
+    def add_context_entry(self):
+        self.context_entries.append(ContextEntry(self.context_count))
+        self.mount(self.context_entries[-1], before="#add_context_entry")
+        self.context_count += 1
 
     @textual.on(textual.widgets.Button.Pressed, "#save")
     def save(self):
         to_save = []
-        for entry in self.config_entries:
+        for entry in self.context_entries:
             to_save.append({})
             write_to = to_save[-1]
             archive = entry.archive.input_path
@@ -392,7 +394,7 @@ class ConfigTab(textual.widgets.Static):
             container_prefix = entry.container_prefix.value
             if len(container_prefix) > 0:
                 write_to["containerPrefix"] = container_prefix
-        file_to_save = self.config_input.input_path + "/" + self.config_name.value
+        file_to_save = self.context_input.input_path + "/" + self.context_name.value
         try:
             with open(file_to_save, "w") as f:
                 f.write(json.dumps(to_save, indent=2))
@@ -403,7 +405,7 @@ class ConfigTab(textual.widgets.Static):
 
     @textual.on(textual.widgets.Button.Pressed, "#load")
     def load(self):
-        file_to_load = self.config_input.input_path + "/" + self.config_name.value
+        file_to_load = self.context_input.input_path + "/" + self.context_name.value
         try:
             with open(file_to_load, "r") as config_file:
                 js = json.load(config_file)
@@ -414,14 +416,14 @@ class ConfigTab(textual.widgets.Static):
             self.app.notify(f"Error when parsing JSON in {file_to_load}")
             return
         # Delete all other entries
-        for ce in self.config_entries:
+        for ce in self.context_entries:
             ce.remove()
-        self.config_entries = []
-        self.config_number = 1
+        self.context_entries = []
+        self.context_count = 1
         for entry in js:
-            self.config_entries.append(ConfigEntry(self.config_number))
-            self.config_number += 1
-            cur_entry = self.config_entries[-1]
+            self.context_entries.append(ContextEntry(self.context_count))
+            self.context_count += 1
+            cur_entry = self.context_entries[-1]
             if "archive" in entry:
                 cur_entry.archive.input_path = entry["archive"]
             if "extractPaths" in entry:
@@ -431,8 +433,8 @@ class ConfigTab(textual.widgets.Static):
                 cur_entry.install_prefix.value = entry["installPrefix"]
             if "containerPrefix" in entry:
                 cur_entry.container_prefix.value = entry["containerPrefix"]
-        for entry in self.config_entries:
-            self.mount(entry, before="#add_config_entry")
+        for entry in self.context_entries:
+            self.mount(entry, before="#add_context_entry")
 
 
 # TODO: Rewrite to use ContentSwitcher?
@@ -450,7 +452,7 @@ class TUI(textual.app.App):
         super().__init__()
         self.generate_tab = GenerateTab()
         self.merge_tab = MergeTab()
-        self.config_tab = ConfigTab()
+        self.context_tab = ContextTab()
 
     def compose(self) -> textual.app.ComposeResult:
         yield textual.widgets.Header()
@@ -461,8 +463,8 @@ class TUI(textual.app.App):
                 yield self.generate_tab
             with textual.widgets.TabPane("Merge"):
                 yield self.merge_tab
-            with textual.widgets.TabPane("Config"):
-                yield self.config_tab
+            with textual.widgets.TabPane("Context"):
+                yield self.context_tab
 
     def action_toggle_dark(self) -> None:
         """A binding for toggling dark mode"""
@@ -475,6 +477,6 @@ class TUI(textual.app.App):
 
 @click.command("tui")
 def tui():
-    """Create a configuration input file with a TUI"""
+    """Run the Surfactant TUI for generating and merging SBOMs."""
     app = TUI()
     app.run()

--- a/surfactant/ui-resources/tui.tcss
+++ b/surfactant/ui-resources/tui.tcss
@@ -45,7 +45,7 @@ YesNoScreen > Label {
    width: 1fr;
 }
 
-Config #config_entries {
+Context #context_entries {
    width: 100%;
 }
 
@@ -66,6 +66,6 @@ ExtractPathSelector {
    layout: horizontal;
 }
 
-ConfigEntry {
+ContextEntry {
    border: solid white;
 }


### PR DESCRIPTION
Rename the specimen configuration file to the specimen context file. As part of this terminology update, the special prefixes used by the generate subcommand now expects `context:` instead of `config:`, which is a breaking change.