### PR TITLE
fix: id magic returning empty list blocked other id plugins

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -323,7 +323,7 @@ def sbom(
                     pm,
                     new_sbom,
                     entry.archive,
-                    filetype=pm.hook.identify_file_type(filepath=entry.archive),
+                    filetype=pm.hook.identify_file_type(filepath=entry.archive) or [],
                     user_institution_name=recorded_institution,
                     skip_extraction=entry.skipProcessingArchive,
                     container_prefix=entry.containerPrefix,
@@ -384,7 +384,6 @@ def sbom(
                 if epath.is_file():
                     entries = []
                     filepath = epath.as_posix()
-                    # breakpoint()
                     try:
                         sw_parent, sw_children = get_software_entry(
                             contextQ,
@@ -392,7 +391,7 @@ def sbom(
                             pm,
                             new_sbom,
                             filepath,
-                            filetype=pm.hook.identify_file_type(filepath=filepath),
+                            filetype=pm.hook.identify_file_type(filepath=filepath) or [],
                             root_path=epath.parent.as_posix() if len(epath.parts) > 1 else "",
                             container_uuid=parent_uuid,
                             install_path=install_prefix,
@@ -505,7 +504,7 @@ def sbom(
                                         pm,
                                         new_sbom,
                                         filepath,
-                                        filetype=ftype,
+                                        filetype=ftype or [],
                                         root_path=epath.as_posix(),
                                         container_uuid=parent_uuid,
                                         install_path=install_prefix,

--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -251,4 +251,4 @@ def identify_file_type(filepath: str) -> Optional[str]:
     except FileNotFoundError:
         return None
 
-    return filetype_matches
+    return filetype_matches if filetype_matches else None


### PR DESCRIPTION
The filetypeid plugin for recognizing files based on magic bytes is set to always run first, however since when it doesn't detect a file it returns an empty list instead of `None` it would block all other methods of identifying a file type from running.