### PR TITLE
fix: missing section in grype plugin pyproject.toml

### DIFF
--- a/plugins/grype/pyproject.toml
+++ b/plugins/grype/pyproject.toml
@@ -33,3 +33,8 @@ test = ["pytest", "docker>=6.1.3", "requests>=2.31.0", "pytest>=7.0.0"]
 
 [tool.setuptools]
 py-modules=["surfactantplugin_grype"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "node-and-date"
+fallback_version = "0.0.1"


### PR DESCRIPTION
Installing the grype plugin was failing in the CI job due to a missing setuptools_scm section in pyproject.toml, and not having a fallback version (likely having trouble detecting correct version to use due to being in a subfolder... need to decide how to version plugins later).