### PR TITLE
fix: magic byte file type id for macho also being identified as a javaclass file

### DIFF
--- a/surfactant/filetypeid/id_magic.py
+++ b/surfactant/filetypeid/id_magic.py
@@ -140,7 +140,8 @@ def identify_file_type(filepath: str) -> Optional[str]:
                 # https://github.com/file/file/blob/master/magic/Magdir/cafebabe
                 if int.from_bytes(magic_bytes[4:8], byteorder="big", signed=False) <= 30:
                     filetype_matches.append("MACHOFAT")
-                filetype_matches.append("JAVACLASS")
+                else:
+                    filetype_matches.append("JAVACLASS")
             if magic_bytes[:4] == b"\xbe\xba\xfe\xca":
                 filetype_matches.append("MACHOFAT")
             if magic_bytes[:4] in [b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca"]:


### PR DESCRIPTION
Fixes a bug where a macho file with magic bytes matching a javaclass file would also always be identified as javaclass files, without taking into account the correct heuristic using the next 4 bytes.