### PR TITLE
fix: store mach-o signature content as hex string instead of lief memoryview

### DIFF
--- a/surfactant/infoextractors/mach_o_file.py
+++ b/surfactant/infoextractors/mach_o_file.py
@@ -105,8 +105,13 @@ def extract_mach_o_info(filename: str) -> object:
                 "size": signature.data_size,
                 "type": signature_type,
             }
-            if __include_signature_content:
-                details["signature"]["content"] = signature.content
+
+            # signature is a memoryview in lief, turn it into a hex string
+            # this avoid serialization errors later when outputting an SBOM
+            if __include_signature_content and hasattr(signature.content, "hex"):
+                details["signature"]["content"] = signature.content.hex()
+            else:
+                details["signature"]["content"] = None
 
         # Extract library dependencies
         for library in binary.libraries:


### PR DESCRIPTION
Fixes another bug encountered, this time due to lief memoryview data type being unserializable for mach-o file signature contents.