### PR TITLE
Error handling for msi files with missing .cab files and some other OLE-specific errors

### DIFF
--- a/surfactant/infoextractors/ole_file.py
+++ b/surfactant/infoextractors/ole_file.py
@@ -132,16 +132,21 @@ def extract_ole_info(filename: str) -> Dict[str, Any]:
 def extract_msi(filename: str, output_folder: str) -> List[Tuple[str, str]]:
     output_path = Path(output_folder)
 
-    with pymsi.Package(Path(filename)) as package:
-        msi = pymsi.Msi(package, True)
+    try:
+        with pymsi.Package(Path(filename)) as package:
+            msi = pymsi.Msi(package, True)
 
-        preprocess_msi_decompression(msi)
+            preprocess_msi_decompression(msi)
 
-        entries = extract_msi_root(msi.root, output_path)
-        if entries:
-            logger.debug(f"Extracted {entries}")
-            logger.info(f"Extracted MSI contents to {output_path}")
-        return entries
+            entries = extract_msi_root(msi.root, output_path)
+            if entries:
+                logger.debug(f"Extracted {entries}")
+                logger.info(f"Extracted MSI contents to {output_path}")
+            return entries
+    except (FileNotFoundError, UnicodeDecodeError, ValueError, OSError, KeyError) as e:
+        # if the msi files are missing .cab files, FileNotFoundError will catch it
+        logger.warning(f"Issue with MSI extraction: {e}")
+        return []
 
 
 def preprocess_msi_decompression(msi: pymsi.Msi):


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

<!-- please finish the following statement -->

If merged this pull request will stop Surfactant from silently crashing on some MSI files. 

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->
Adding some error handling so that SBOM generation can still happen.
