### PR TITLE
feat: Enable more complex regexes to be parsed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "requests>=2.32.3",
     "rarfile==4.2.*",
     "networkx>=2.6",
+    "regex; platform_python_implementation == 'CPython'",
     # Pinned to specific version for potential breaking changes
     "python-msi==0.0.0a3",
     # Pinned to specific version for potential breaking changes

--- a/surfactant/infoextractors/js_file.py
+++ b/surfactant/infoextractors/js_file.py
@@ -7,8 +7,14 @@
 #
 # SPDX-License-Identifier: MIT
 import json
-import re
 from typing import Any, Dict, List, Optional
+
+# regex adds features that built-in re module is missing
+# e.g. variable width look-behind
+try:
+    import regex as re
+except ImportError:
+    import re
 
 # from pluggy import get_plugin_manager, get_plugin
 from loguru import logger
@@ -82,12 +88,8 @@ class RetireJSDatabaseManager(BaseDatabaseManager):
                                 re.compile(replaced.encode("utf-8"))  # Validate regex
                                 clean_db[library][entry].append(replaced)
                             except re.error as rex:
-                                logger.error(
-                                    "Invalid regex for %s[%s]: %r — %s",
-                                    library,
-                                    entry,
-                                    replaced,
-                                    rex,
+                                logger.warning(
+                                    f"Unable to compile retirejs regex for {library}[{entry}], pattern will not be used to recognize {library}: {replaced} — {rex}"
                                 )
 
         return clean_db

--- a/surfactant/infoextractors/native_lib_file.py
+++ b/surfactant/infoextractors/native_lib_file.py
@@ -7,8 +7,14 @@
 #
 # SPDX-License-Identifier: MIT
 import os
-import re
 from typing import Any, Dict, List, Optional, Set, Union
+
+# regex adds features that built-in re module is missing
+# e.g. variable width look-behind
+try:
+    import regex as re
+except ImportError:
+    import re
 
 from loguru import logger
 


### PR DESCRIPTION
When using a support CPython interpreter, use the regex module from PyPI instead of the built in re module so that regexes with things like variable width look-behind can be used.

Fixes #538 "Invalid regex" error upon getting or updating Javascript plugin Also should resolve a similar issue with some regex in emba database on older Python versions