### PR TITLE
fix: Ensure stable order for elfDependencies

### DIFF
--- a/surfactant/infoextractors/elf_file.py
+++ b/surfactant/infoextractors/elf_file.py
@@ -169,8 +169,8 @@ def extract_elf_info(filename: str) -> object:
                         # Shared libraries
                         file_details["elfDependencies"].add(tag.needed)
 
-        # Ensure the set of dependencies is JSON-encodable
-        file_details["elfDependencies"] = list(file_details["elfDependencies"])
+        # Ensure the set of dependencies is JSON-encodable, and has a stable ordering
+        file_details["elfDependencies"] = sorted(file_details["elfDependencies"])
 
         if elf["e_type"] == "ET_EXEC":
             file_details["elfIsExe"] = True


### PR DESCRIPTION
#507 changed the elfDependencies to a set that gets turned into a list, but the order isn't stable across runs (so some regression tests in PRs are showing changes). This change ensures a stable ordering of elements when it gets converted to a list.