### PR TITLE
build!: Use SPDX license expressions and require setuptools>=77.0.3

### DIFF
--- a/plugins/SBOMVis/pyproject.toml
+++ b/plugins/SBOMVis/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,14 +11,13 @@ description = "Surfactant SBOM Visualization"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "dataclasses_json",

--- a/plugins/angrimportfinder/pyproject.toml
+++ b/plugins/angrimportfinder/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,14 +11,13 @@ description = "Surfactant Imported Function Extractor"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "angr",

--- a/plugins/binary2strings/pyproject.toml
+++ b/plugins/binary2strings/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/plugins/checksec.py/pyproject.toml
+++ b/plugins/checksec.py/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,14 +11,13 @@ description = "Surfactant checksec.py"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "checksec.py",

--- a/plugins/cvebin2vex/pyproject.toml
+++ b/plugins/cvebin2vex/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/plugins/dapper/pyproject.toml
+++ b/plugins/dapper/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,7 +11,7 @@ description = "Surfactant plugin for looking up package information in Dapper da
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["surfactant"]
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",

--- a/plugins/fuzzyhashes/pyproject.toml
+++ b/plugins/fuzzyhashes/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/plugins/grype/pyproject.toml
+++ b/plugins/grype/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/plugins/syft/pyproject.toml
+++ b/plugins/syft/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +12,7 @@ description = "Surfactant syft"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = ["surfactant"]
-license = {text = "BSD-3-Clause"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Use SPDX license expressions instead of license classifiers and require setuptool>=77.0.3, which added support for license expressions. 2026-Feb-18 is the deadline to remove the deprecated ways of specifying licenses.

Resolves #542

BREAKING CHANGE: Builds now require setuptools>=77.0.3