### PR TITLE
Plugin context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All contributions to Surfactant are made under the MIT license (MIT).
 
 ### For Developers:
 
-1. Create a virtual environment with python >= 3.8 [Optional, but recommended]
+1. Create a virtual environment with python >= 3.10 [Optional, but recommended]
 
 ```bash
 python -m venv venv

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,7 +48,7 @@ pip install git+https://github.com/LLNL/Surfactant#subdirectory=plugins/fuzzyhas
 
 ### For Developers:
 
-1. Create a virtual environment with python >= 3.9 [Optional, but recommended]
+1. Create a virtual environment with python >= 3.10 [Optional, but recommended]
 
 ```bash
 python -m venv venv

--- a/surfactant/context.py
+++ b/surfactant/context.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Lawrence Livermore Natioanl Security, LLC
+# Copyright 2026 Lawrence Livermore Natioanl Security, LLC
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from inspect import getframeinfo, stack
 from typing import Any, Dict, List, Optional
 
-import loguru
+from loguru import logger
 
 
 @dataclass
@@ -58,24 +58,24 @@ class ContextEntry:
         """
         if not self.pluginConf:
             caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            logger.debug(
                 f"No plugin configuration present, using default value: {default} for {name}: {conf_key}"
             )
             return default
         module = self.pluginConf[name]
         if not module:
             caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            logger.debug(
                 f"No plugin configuration for {name}, using default value: {default} for {conf_key}"
             )
             return default
         field = module[conf_key]
         if not field:
             caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            logger.debug(
                 f"No plugin configuration for {name}: {conf_key}, using default value: {default}"
             )
             return default

--- a/surfactant/context.py
+++ b/surfactant/context.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional, Dict, Any
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -41,4 +41,4 @@ class ContextEntry:
     excludeFileExts: Optional[List[str]] = None
     skipProcessingArchive: Optional[bool] = False
     containerPrefix: Optional[str] = None
-    pluginConf: Optional[Dict[str,Any]] = None
+    pluginConf: Optional[Dict[str, Any]] = None

--- a/surfactant/context.py
+++ b/surfactant/context.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Dict, Any
 
 
 @dataclass
@@ -30,6 +30,7 @@ class ContextEntry:
             Software entry for the archive file will only contain basic information such as hashes. Default is False.
         containerPrefix (Optional[str]): The prefix to use for the generated SBOM's containerPath.  Used to indicate that the
             `extractPaths` specified should map to a specific subfolder within the corresponding archive file.
+        pluginConf (Optional[Dict[str,Any]]): Configuration information for specific plugins. See individual plugins for defaults.
     """
 
     extractPaths: List[str]
@@ -40,3 +41,4 @@ class ContextEntry:
     excludeFileExts: Optional[List[str]] = None
     skipProcessingArchive: Optional[bool] = False
     containerPrefix: Optional[str] = None
+    pluginConf: Optional[Dict[str,Any]] = None

--- a/surfactant/context.py
+++ b/surfactant/context.py
@@ -1,9 +1,12 @@
-# Copyright 2023 Lawrence Livermore Natioanl Security, LLC
+# Copyright 2025 Lawrence Livermore Natioanl Security, LLC
 # See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+from inspect import getframeinfo, stack
 from typing import Any, Dict, List, Optional
+
+import loguru
 
 
 @dataclass
@@ -30,7 +33,8 @@ class ContextEntry:
             Software entry for the archive file will only contain basic information such as hashes. Default is False.
         containerPrefix (Optional[str]): The prefix to use for the generated SBOM's containerPath.  Used to indicate that the
             `extractPaths` specified should map to a specific subfolder within the corresponding archive file.
-        pluginConf (Optional[Dict[str,Any]]): Configuration information for specific plugins. See individual plugins for defaults.
+        pluginConf (Optional[Dict[str, Any]]): Configuration information for specific plugins.
+            See plugin docstrings or documentation for configuration details.
     """
 
     extractPaths: List[str]
@@ -42,3 +46,37 @@ class ContextEntry:
     skipProcessingArchive: Optional[bool] = False
     containerPrefix: Optional[str] = None
     pluginConf: Optional[Dict[str, Any]] = None
+
+    def get_pconf(self, name: str, conf_key: str, default: Optional[Any]) -> Optional[Any]:
+        """
+        Get the value of a plugin's configuration
+
+        Args:
+            name (str): The plugin to look for.  (Ex. surfactant.plugin.capa) Use __name__ if looking for a plugin's own configuration.
+            conf_key (str): Configuration option to look for in the pluginConf dictionary.
+            default (Optional[Any]): Default value to use if conf_key has no associated value
+        """
+        if not self.pluginConf:
+            caller = getframeinfo(stack()[1][0])
+            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            loguru.debug(
+                f"No plugin configuration present, using default value: {default} for {name}: {conf_key}"
+            )
+            return default
+        module = self.pluginConf[name]
+        if not module:
+            caller = getframeinfo(stack()[1][0])
+            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            loguru.debug(
+                f"No plugin configuration for {name}, using default value: {default} for {conf_key}"
+            )
+            return default
+        field = module[conf_key]
+        if not field:
+            caller = getframeinfo(stack()[1][0])
+            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
+            loguru.debug(
+                f"No plugin configuration for {name}: {conf_key}, using default value: {default}"
+            )
+            return default
+        return field

--- a/surfactant/context.py
+++ b/surfactant/context.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
-from inspect import getframeinfo, stack
+
+# from inspect import getframeinfo, stack
 from typing import Any, Dict, List, Optional
 
-import loguru
+from loguru import logger
 
 
 @dataclass
@@ -57,25 +58,19 @@ class ContextEntry:
             default (Optional[Any]): Default value to use if conf_key has no associated value
         """
         if not self.pluginConf:
-            caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.debug(
                 f"No plugin configuration present, using default value: {default} for {name}: {conf_key}"
             )
             return default
         module = self.pluginConf[name]
         if not module:
-            caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.debug(
                 f"No plugin configuration for {name}, using default value: {default} for {conf_key}"
             )
             return default
         field = module[conf_key]
         if not field:
-            caller = getframeinfo(stack()[1][0])
-            loguru.trace(f"get_pconf() called from {caller.filename}:{caller.lineno}")
-            loguru.debug(
+            logger.debug(
                 f"No plugin configuration for {name}: {conf_key}, using default value: {default}"
             )
             return default

--- a/surfactant/infoextractors/rpm_file.py
+++ b/surfactant/infoextractors/rpm_file.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
+from surfactant.context import ContextEntry
 
 # from surfactant.context import ContextEntry   # Present for use in future extraction implementation
 
@@ -119,10 +120,17 @@ def extract_file_info(
     filetype: List[str],
     software_field_hints: List[Tuple[str, object, int]],
     # context_queue: "Queue[ContextEntry]",     # Present for use in future extraction implementation
-    # current_context: Optional[ContextEntry],
+    current_context: Optional[ContextEntry],
 ) -> object:
     if not supports_file(filetype):
         return None
+    logger.warning(f"ContextEntry contains: {current_context}")
+    # if current_context and current_context.pluginConf and "surfactant.infoextractors.rpm_file" in current_context.pluginConf:
+    #     config = current_context.pluginConf["surfactant.infoextractors.rpm_file"]
+    #     logger.warning(f"ContextEntry contains: {config}")
+    #     if "mountPrefix" in config:
+    #         mount_prefix = config["mountPrefix"]
+    #         logger.warning(f"ContextEntry contains: {config}")
     rpm_info = extract_rpm_info(filename)
 
     for key in rpm_info["rpm"]:

--- a/surfactant/infoextractors/rpm_file.py
+++ b/surfactant/infoextractors/rpm_file.py
@@ -12,7 +12,6 @@ from loguru import logger
 
 import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Software
-from surfactant.context import ContextEntry
 
 # from surfactant.context import ContextEntry   # Present for use in future extraction implementation
 

--- a/surfactant/infoextractors/rpm_file.py
+++ b/surfactant/infoextractors/rpm_file.py
@@ -120,17 +120,10 @@ def extract_file_info(
     filetype: List[str],
     software_field_hints: List[Tuple[str, object, int]],
     # context_queue: "Queue[ContextEntry]",     # Present for use in future extraction implementation
-    current_context: Optional[ContextEntry],
+    # current_context: Optional[ContextEntry],
 ) -> object:
     if not supports_file(filetype):
         return None
-    logger.warning(f"ContextEntry contains: {current_context}")
-    # if current_context and current_context.pluginConf and "surfactant.infoextractors.rpm_file" in current_context.pluginConf:
-    #     config = current_context.pluginConf["surfactant.infoextractors.rpm_file"]
-    #     logger.warning(f"ContextEntry contains: {config}")
-    #     if "mountPrefix" in config:
-    #         mount_prefix = config["mountPrefix"]
-    #         logger.warning(f"ContextEntry contains: {config}")
     rpm_info = extract_rpm_info(filename)
 
     for key in rpm_info["rpm"]:


### PR DESCRIPTION
### Summary

If merged, this pull request will add the ability to implement settings for plugins associated with specific context entries.

### Proposed changes

Add a new field to the ContextEntry class. Example config file:

```json
[
  {
    "extractPaths": [
      "./tests/data/rpm_pkg_files"
    ],
    "pluginConf": {
      "surfactant.plugin.qilingexec": {
        "mountPrefix": "/"
      },
     "surfactant.plugin.import.angr": {
      "useThisDir": "/Users/home/rootf"
      }
    }
  }
]
```