### PR TITLE
Freezetime fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,14 +67,14 @@ dependencies = [
 dynamic = ["version"]
 
 [dependency-groups]
-test = ["pytest", "pytest-asyncio", "jsonschema[format-nongpl]"]
+test = ["pytest", "pytest-asyncio", "jsonschema[format-nongpl]", "freezegun"]
 dev = ["build", "pre-commit"]
 docs = ["sphinx", "myst-parser", "furo>=2025.9.25", "sphinx-copybutton>=0.5.2"]
 
 [project.optional-dependencies]
 macho = ["lief==0.17.6"]
 java = ["javatools>=1.6,==1.*"]
-test = ["pytest", "pytest-asyncio", "jsonschema[format-nongpl]"]
+test = ["pytest", "pytest-asyncio", "jsonschema[format-nongpl]", "freezegun"]
 dev = ["build", "pre-commit"]
 docs = ["sphinx", "myst-parser", "furo>=2025.9.25", "sphinx-copybutton>=0.5.2"]
 

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -14,12 +14,12 @@ import sys
 import traceback
 import uuid
 from contextlib import contextmanager
-from freezegun import freeze_time
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
 
 import click
+from freezegun import freeze_time
 from loguru import logger
 
 from surfactant.cmd.generate import sbom
@@ -58,7 +58,9 @@ def deterministic_context(enabled: bool = True):
     """
     if enabled:
         # Calculate the frozen time
-        frozen_time = datetime.datetime.fromtimestamp(deterministic_time(), tz=datetime.timezone.utc)
+        frozen_time = datetime.datetime.fromtimestamp(
+            deterministic_time(), tz=datetime.timezone.utc
+        )
         with (
             freeze_time(frozen_time),
             patch("uuid.uuid4", side_effect=deterministic_uuid4),

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -11,10 +11,10 @@ import json
 import os
 import random
 import sys
-import time
 import traceback
 import uuid
 from contextlib import contextmanager
+from freezegun import freeze_time
 from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
@@ -49,16 +49,6 @@ def deterministic_json_dump(*args, **kwargs):
     return _json_dump(*args, **kwargs)
 
 
-class FixedDateTime(datetime.datetime):
-    @classmethod
-    def now(cls, tz=None):
-        return cls.fromtimestamp(time.time(), tz)
-
-    @classmethod
-    def utcnow(cls):
-        return cls.fromtimestamp(time.time(), datetime.timezone.utc)
-
-
 @contextmanager
 def deterministic_context(enabled: bool = True):
     """Context manager to optionally patch time-related and random functions for deterministic output.
@@ -67,10 +57,11 @@ def deterministic_context(enabled: bool = True):
         enabled (bool): If True, applies patches for deterministic behavior. If False, no patches are applied.
     """
     if enabled:
+        # Calculate the frozen time
+        frozen_time = datetime.datetime.fromtimestamp(deterministic_time(), tz=datetime.timezone.utc)
         with (
+            freeze_time(frozen_time),
             patch("uuid.uuid4", side_effect=deterministic_uuid4),
-            patch("datetime.datetime", FixedDateTime),
-            patch("time.time", side_effect=deterministic_time),
             patch("json.dumps", side_effect=deterministic_json_dumps),
             patch("json.dump", side_effect=deterministic_json_dump),
         ):


### PR DESCRIPTION
Use freezegun to fix capture time freezing in regression tests.