### PR TITLE
fix: resolve_link crashes on multi-hop symlinks

### DIFF
--- a/surfactant/cmd/generate.py
+++ b/surfactant/cmd/generate.py
@@ -903,7 +903,7 @@ def resolve_link(
     current_path = pathlib.Path(path)
     steps = 0
 
-    while current_path.is_symlink:
+    while current_path.is_symlink():
         # If we've already seen this then we're in an infinite loop
         if current_path in seen_paths:
             logger.warning(f"Resolving symlink {path} encountered infinite loop at {current_path}")
@@ -928,7 +928,7 @@ def resolve_link(
             dest = dest[1:]
         # Rebase to get the true location
         current_path = pathlib.Path(extract_dir) / dest
-        cur_dir = current_path.parent
+        cur_dir = str(current_path.parent)
     if not current_path.exists():
         logger.warning(f"Resolved symlink {path} to a path that doesn't exist {current_path}")
         return None


### PR DESCRIPTION
## Summary

`resolve_link()` crashes when processing packages that use a standard soname symlink chain (e.g. `libhelics.so` → `libhelics.so.3` → `libhelics.so.3.5.3`). Two bugs in the same function:

- `while current_path.is_symlink:` — missing parentheses means the loop condition is always truthy, so `readlink()` is called on the final regular file, raising `OSError: [Errno 22] Invalid argument`.
- `cur_dir = current_path.parent` — `Path.parent` returns a `Path` object, but `cur_dir` is subscripted as a string on the next iteration, raising `TypeError: 'PosixPath' object is not subscriptable`.

**Fix:** add `()` to `is_symlink()` and wrap `current_path.parent` in `str()`.

## Testing

Ran `surfactant generate` against the HELICS 3.5.3 Linux release (the README's suggested test sample) — previously crashed, now produces a valid SBOM with 68 software entries and 74 relationships. Full test suite passes: 177 passed, 4 skipped.