### PR TITLE
Hide Read the Docs addons flyout in sbom-workbench.html

### DIFF
--- a/docs/_static_html/sbom-workbench.html
+++ b/docs/_static_html/sbom-workbench.html
@@ -471,6 +471,11 @@
   /* Wave/blink */
   @keyframes blink { 50% { opacity: 0.3; } }
   .blink { animation: blink 1.2s infinite; }
+
+  /* Hide the Read the Docs addons flyout on this page only */
+  readthedocs-flyout {
+    display: none !important;
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
Added CSS to hide the Read the Docs addons flyout on the page.