### PR TITLE
feat: add Graphviz DOT output writer

### DIFF
--- a/surfactant/output/dot_writer.py
+++ b/surfactant/output/dot_writer.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import surfactant.plugin
+from surfactant.sbomtypes import SBOM, Software
+
+
+def _escape(text: str) -> str:
+    """Escape a string for use inside a DOT double-quoted ID."""
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _node_label(software: Software) -> str:
+    """Pick a human-readable label for a software node.
+
+    Prefer a file name, then a recorded name, and fall back to the UUID so
+    every node is always labeled with something.
+    """
+    if software.fileName:
+        return software.fileName[0]
+    if software.name:
+        for entry in software.name:
+            value = getattr(entry, "nameValue", None)
+            if value:
+                return value
+    return software.UUID
+
+
+@surfactant.plugin.hookimpl
+def write_sbom(sbom: SBOM, outfile) -> None:
+    """Write the SBOM's software and their relationships as a Graphviz DOT digraph.
+
+    Each software entry becomes a node and each logical relationship becomes a
+    directed edge labeled with the relationship type. Filesystem/symlink edges
+    are omitted so the graph matches the logical relationships emitted in the
+    SBOM's JSON output.
+    """
+    outfile.write("digraph SBOM {\n")
+    outfile.write("    rankdir=LR;\n")
+    outfile.write("    node [shape=box];\n")
+
+    # Emit a labeled node for every software entry, and remember which UUIDs
+    # are software so we only draw edges between known nodes.
+    software_uuids = set()
+    if sbom.software:
+        for sw in sbom.software:
+            software_uuids.add(sw.UUID)
+            outfile.write(f'    "{_escape(sw.UUID)}" [label="{_escape(_node_label(sw))}"];\n')
+
+    # Emit logical relationships only. Mirror the filtering used when writing
+    # relationships to the SBOM JSON: drop symlink edges and any edge touching
+    # a filesystem "path" node.
+    for u, v, key, _attrs in sbom.graph.edges(keys=True, data=True):
+        if str(key).lower() == "symlink":
+            continue
+        utype = sbom.graph.nodes.get(u, {}).get("type")
+        vtype = sbom.graph.nodes.get(v, {}).get("type")
+        if utype == "path" or vtype == "path":
+            continue
+        if u not in software_uuids or v not in software_uuids:
+            continue
+        outfile.write(f'    "{_escape(u)}" -> "{_escape(v)}" [label="{_escape(str(key))}"];\n')
+
+    outfile.write("}\n")
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> str | None:
+    return "dot"

--- a/surfactant/plugin/manager.py
+++ b/surfactant/plugin/manager.py
@@ -36,6 +36,7 @@ def _register_plugins(pm: pluggy.PluginManager) -> None:
         csv_writer,
         cyclonedx_writer,
         cytrics_writer,
+        dot_writer,
         spdx_writer,
     )
     from surfactant.relationships import (
@@ -71,6 +72,7 @@ def _register_plugins(pm: pluggy.PluginManager) -> None:
         csv_writer,
         cytrics_writer,
         cyclonedx_writer,
+        dot_writer,
         spdx_writer,
         cytrics_reader,
         native_lib_file,

--- a/tests/output/test_dot_writer.py
+++ b/tests/output/test_dot_writer.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import io
+
+from surfactant.output import dot_writer
+from surfactant.sbomtypes import SBOM, Software
+
+
+def _make_sbom():
+    sbom = SBOM()
+    app = Software(fileName=["app.exe"])
+    lib = Software(fileName=["helper.dll"])
+    sbom.software = [app, lib]
+    sbom.create_relationship(app.UUID, lib.UUID, "Uses")
+    return sbom, app, lib
+
+
+def test_dot_writer_short_name():
+    assert dot_writer.short_name() == "dot"
+
+
+def test_dot_writer_emits_digraph_nodes_and_edges():
+    sbom, app, lib = _make_sbom()
+
+    outfile = io.StringIO()
+    dot_writer.write_sbom(sbom, outfile)
+    output = outfile.getvalue()
+
+    # Well-formed digraph
+    assert output.startswith("digraph SBOM {")
+    assert output.rstrip().endswith("}")
+
+    # A labeled node for each software entry
+    assert f'"{app.UUID}" [label="app.exe"];' in output
+    assert f'"{lib.UUID}" [label="helper.dll"];' in output
+
+    # The relationship rendered as a labeled directed edge
+    assert f'"{app.UUID}" -> "{lib.UUID}" [label="Uses"];' in output
+
+
+def test_dot_writer_falls_back_to_uuid_label():
+    sbom = SBOM()
+    unnamed = Software()
+    sbom.software = [unnamed]
+
+    outfile = io.StringIO()
+    dot_writer.write_sbom(sbom, outfile)
+    output = outfile.getvalue()
+
+    assert f'"{unnamed.UUID}" [label="{unnamed.UUID}"];' in output
+
+
+def test_dot_writer_handles_empty_sbom():
+    outfile = io.StringIO()
+    dot_writer.write_sbom(SBOM(), outfile)
+    output = outfile.getvalue()
+
+    assert output.startswith("digraph SBOM {")
+    assert output.rstrip().endswith("}")
+    assert "->" not in output


### PR DESCRIPTION
### Summary

If merged this pull request will add a Graphviz DOT output writer, so an SBOM can be exported as a graph showing how files tie together.

Closes #71.

### Proposed changes

- New `surfactant/output/dot_writer.py` implementing the `write_sbom` hook with short name `dot`. It emits a `digraph`:
  - one node per software entry, labeled with its file name (falling back to a recorded name, then the UUID, so every node is labeled);
  - one directed edge per logical relationship, labeled with the relationship type.
- Edge selection mirrors the logical-relationship filtering already used when writing relationships to the SBOM JSON (`to_dict_override`): `symlink` edges and any edge touching a filesystem `path` node are skipped, so the graph reflects software relationships rather than the filesystem tree. Node/edge IDs and labels are escaped for DOT.
- Registered the writer with the internal plugin manager.
- Added `tests/output/test_dot_writer.py` covering node/edge emission, the UUID label fallback, and empty SBOMs.

Usage:

```
surfactant generate <config> <sbom.dot> --output_format surfactant.output.dot_writer
```

then e.g. `dot -Tsvg sbom.dot -o sbom.svg`.

### Testing

- `pytest tests/output/test_dot_writer.py` — 4 passed.
- `pytest tests/cmd/test_plugin.py` — plugin registration still passes with the new writer.
- Rendered a sample SBOM (`tests/data/sample_sboms/helics_binaries_sbom.json`) through the plugin manager: valid `digraph` with 6 nodes and 5 edges.
- `ruff check` and `ruff format --check` clean.

### Notes

@theStache mentioned back in 2023 that they were looking at a `.DOT` output; I did not find a PR for it, so I picked this up. Happy to adjust the node/edge styling or labeling if maintainers prefer a different convention.