### PR TITLE
feat(plugins): add support for ofrak, angr, binja, binwalk plugins

### DIFF
--- a/plugins/angr-expanded/README.md
+++ b/plugins/angr-expanded/README.md
@@ -1,0 +1,113 @@
+# angr-expanded — Expanded angr Binary Analysis Plugin for Surfactant
+
+A Surfactant plugin that uses the [angr](https://github.com/angr/angr) binary
+analysis framework to extract **expanded** metadata from ELF, PE, and Mach-O
+binaries and embed it **directly into the generated SBOM** (not in a separate
+side-car file).
+
+Where the original `angrimportfinder` plugin only records imported/exported
+function names (to an external JSON file), this plugin adds a richer
+`angrExpanded` metadata object to each software entry.
+
+## What information it adds
+
+All data is stored on the software entry's metadata under the `angrExpanded` key:
+
+- **Loader / architecture facts** (cheap, always collected)
+  - `arch`, `bits`, `endianness`
+  - `entryPoint`, `imageBase`, `mappedBase`, `minAddr`, `maxAddr`
+  - `positionIndependent` (PIE/PIC), `executableStack`, `relocatable`
+  - `linkingType`, `staticallyLinked`, `objectFormat`
+  - `linkedLibraries` — direct shared-library dependencies from the loader
+- **Symbols with import→library resolution**
+  - `importedFunctions` — each with `name`, providing `library` (populated for PE
+    imports; ELF imports resolve at runtime), and `isFunction`
+  - `exportedFunctions` — each with `name`, `address`, `isFunction`
+  - `importedFunctionCount`, `exportedFunctionCount`
+- **Minimum library versions** (ELF, cheap)
+  - `minimumLibraryVersions` — per needed library, the highest required version
+    per prefix (e.g. `{"libc.so.6": {"GLIBC": "2.34"}}`). This is the *minimum*
+    library version the binary can run against, derived from the `.gnu.version_r`
+    section. Useful for dependency resolution and narrowing CVE/version matching.
+  - `symbolVersionNeeds` — the full list of versioned symbol tags per library
+- **Section map** (non-ELF only)
+  - `sections` — `name`, `vaddr`, `size`, and `isExecutable`/`isWritable`/`isReadable`.
+    Emitted for **PE and Mach-O** only; ELF section data is already produced by
+    Surfactant's built-in `elf_file` extractor, so it is not duplicated here.
+
+## Relationships
+
+The plugin also implements `establish_relationships`. After metadata is gathered,
+it links each binary's **imported functions** to other SBOM entries that **export**
+those functions, emitting `Uses` relationships. When the importer records
+`linkedLibraries`, matches are restricted to exporters whose file name matches one
+of those libraries to keep the edges high-confidence.
+
+### Example SBOM metadata
+
+```json
+{
+  "angrExpanded": {
+    "arch": "AMD64",
+    "bits": 64,
+    "endianness": "little",
+    "entryPoint": "0x401660",
+    "imageBase": "0x400000",
+    "positionIndependent": false,
+    "executableStack": false,
+    "staticallyLinked": false,
+    "linkedLibraries": ["libc.so.6"],
+    "importedFunctions": [
+      {"name": "printf", "library": null, "isFunction": true}
+    ],
+    "exportedFunctions": [],
+    "importedFunctionCount": 1,
+    "exportedFunctionCount": 0,
+    "sections": [
+      {"name": ".text", "vaddr": "0x401000", "size": 1234, "isExecutable": true,
+       "isWritable": false, "isReadable": true}
+    ]
+  }
+}
+```
+
+> Note: `sections` is present for PE and Mach-O only. For ELF binaries, section
+> data comes from Surfactant's built-in `elf_file` extractor instead.
+
+## Quickstart
+
+In the same virtual environment that Surfactant is installed in:
+
+```bash
+cd plugins/angr-expanded
+pip install .          # or: surfactant plugin install .
+```
+
+For development (editable install):
+
+```bash
+pip install -e .
+```
+
+Then generate an SBOM as usual; ELF/PE/Mach-O entries will include the
+`angrExpanded` metadata:
+
+```bash
+surfactant plugin list          # confirm "angr_expanded" is enabled
+surfactant generate config.json out.json
+```
+
+## Enable / disable the whole plugin
+
+The plugin registers with the short name `angr_expanded`:
+
+```bash
+surfactant plugin disable angr_expanded
+surfactant plugin enable angr_expanded
+```
+
+## Uninstalling
+
+```bash
+pip uninstall surfactantplugin-angr-expanded
+```

--- a/plugins/angr-expanded/pyproject.toml
+++ b/plugins/angr-expanded/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "surfactantplugin-angr-expanded"
+version = "0.1.0"
+authors = [
+    {name = "Benton Wilson", email = "bwilson@nlr.gov"},
+]
+description = "Surfactant plugin providing expanded angr binary analysis metadata"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["surfactant", "angr", "sbom", "binary-analysis"]
+license = "MIT"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+]
+dependencies = [
+    "angr",
+    "surfactant",
+]
+
+[project.entry-points."surfactant"]
+"surfactantplugin_angr_expanded" = "surfactantplugin_angr_expanded"
+
+[tool.setuptools]
+py-modules = ["surfactantplugin_angr_expanded"]

--- a/plugins/angr-expanded/surfactantplugin_angr_expanded.py
+++ b/plugins/angr-expanded/surfactantplugin_angr_expanded.py
@@ -1,0 +1,403 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+"""Surfactant plugin that uses angr to extract loader/symbol binary metadata.
+
+This plugin is scoped to the things angr + CLE do best and cheaply: loader and
+architecture facts, imported/exported symbols, import-to-library resolution
+(which powers the ``Uses`` relationships between binaries), a section map, and
+ELF versioned-symbol minimums useful for CVE/version matching.
+
+Structural code analysis that Binary Ninja does with higher fidelity (function
+recovery, the call graph, notable-API cross-references, typed prototypes) is
+deliberately left to the ``binaryninja_info`` plugin so the two produce
+complementary, non-overlapping records on the same binary.
+
+The metadata is grouped under the ``angrExpanded`` key on each software entry.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import angr
+from cle import CLECompatibilityError, CLEError
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
+from elftools.elf.gnuversions import GNUVerNeedSection
+from loguru import logger
+
+import surfactant.plugin
+from surfactant.sbomtypes import SBOM, Relationship, Software
+
+# Top-level key the metadata object is stored under in the software entry.
+_METADATA_KEY = "angrExpanded"
+
+# Settings base name for this plugin.
+_SETTINGS_SECTION = "angr_expanded"
+
+
+def supports_file(filetype: list[str]) -> bool:
+    """Return True for file types that angr's loader can analyze."""
+    return any(t in filetype for t in ("ELF", "PE", "MACHOFAT", "MACHO"))
+
+
+def _hex(value: Any) -> Any:
+    """Render integer addresses as hex strings, pass everything else through."""
+    if isinstance(value, int):
+        return hex(value)
+    return value
+
+
+def _collect_loader_info(project: "angr.Project") -> dict[str, Any]:
+    """Collect cheap loader/architecture facts that don't require code analysis."""
+    loader = project.loader
+    main = loader.main_object
+    arch = project.arch
+
+    endianness = "little" if getattr(arch, "memory_endness", "") == "Iend_LE" else "big"
+
+    info: dict[str, Any] = {
+        "arch": getattr(arch, "name", None),
+        "bits": getattr(arch, "bits", None),
+        "endianness": endianness,
+        "entryPoint": _hex(getattr(project, "entry", None)),
+        "imageBase": _hex(getattr(main, "linked_base", None)),
+        "mappedBase": _hex(getattr(main, "mapped_base", None)),
+        "minAddr": _hex(main.min_addr) if hasattr(main, "min_addr") else None,
+        "maxAddr": _hex(main.max_addr) if hasattr(main, "max_addr") else None,
+        "positionIndependent": bool(getattr(main, "pic", False)),
+        "executableStack": bool(getattr(main, "execstack", False)),
+        "relocatable": bool(getattr(main, "is_main_bin", True) is False)
+        or bool(getattr(main, "pic", False)),
+        "linkingType": getattr(main, "linking", None),
+        "objectFormat": type(main).__name__,
+    }
+
+    # Direct shared-library dependencies as recorded by the loader.
+    deps = getattr(main, "deps", None)
+    info["linkedLibraries"] = sorted(str(d) for d in deps) if deps else []
+
+    # Statically linked binaries have no recorded dynamic dependencies and are not
+    # marked as dynamically linked by cle.
+    linking = getattr(main, "linking", None)
+    if linking is not None:
+        info["staticallyLinked"] = linking == "static"
+    else:
+        info["staticallyLinked"] = not info["linkedLibraries"]
+
+    return info
+
+
+def _collect_symbols(project: "angr.Project") -> dict[str, Any]:
+    """Collect imported/exported symbols with import-to-library resolution."""
+    main = project.loader.main_object
+
+    imported: list[dict[str, Any]] = []
+    exported: list[dict[str, Any]] = []
+    seen_imports: set[tuple[str, Any]] = set()
+    seen_exports: set[str] = set()
+
+    for symbol in getattr(main, "symbols", []):
+        name = getattr(symbol, "name", None)
+        if not name:
+            continue
+        if getattr(symbol, "is_import", False):
+            # PE binaries record the providing DLL per-symbol; ELF imports are
+            # resolved at runtime so library is usually None.
+            library = getattr(symbol, "libname", None)
+            key = (name, library)
+            if key in seen_imports:
+                continue
+            seen_imports.add(key)
+            imported.append(
+                {
+                    "name": name,
+                    "library": library,
+                    "isFunction": bool(getattr(symbol, "is_function", False)),
+                }
+            )
+        elif getattr(symbol, "is_export", False):
+            if name in seen_exports:
+                continue
+            seen_exports.add(name)
+            exported.append(
+                {
+                    "name": name,
+                    "address": _hex(getattr(symbol, "rebased_addr", None)),
+                    "isFunction": bool(getattr(symbol, "is_function", False)),
+                }
+            )
+
+    imported.sort(key=lambda s: s["name"])
+    exported.sort(key=lambda s: s["name"])
+    return {
+        "importedFunctions": imported,
+        "exportedFunctions": exported,
+        "importedFunctionCount": len(imported),
+        "exportedFunctionCount": len(exported),
+    }
+
+
+def _parse_symbol_version(version: str) -> tuple[str, tuple[int, ...] | None]:
+    """Split a versioned symbol tag into a (prefix, numeric version) pair.
+
+    Examples:
+        ``GLIBC_2.34`` -> (``GLIBC``, (2, 34))
+        ``GLIBCXX_3.4.29`` -> (``GLIBCXX``, (3, 4, 29))
+        ``LIBSELINUX_1.0`` -> (``LIBSELINUX``, (1, 0))
+        ``GLIBC_PRIVATE`` -> (``GLIBC``, None)  # non-numeric, not comparable
+    """
+    prefix, _, rest = version.rpartition("_")
+    if not prefix:
+        return version, None
+    parts = rest.split(".")
+    if parts and all(p.isdigit() for p in parts):
+        return prefix, tuple(int(p) for p in parts)
+    return prefix, None
+
+
+def _collect_symbol_versions(filename: str) -> dict[str, Any]:
+    """Extract ELF versioned-symbol requirements and derive minimum library versions.
+
+    Reads the ``.gnu.version_r`` (version needs) section using pyelftools and
+    computes, for each needed library and version prefix (e.g. ``GLIBC``), the
+    highest version required by any imported symbol. That highest value is the
+    *minimum* library version the binary can run against, which is useful for
+    dependency resolution and narrowing CVE/version matching.
+
+    Returns an empty dict for non-ELF files or files without version needs.
+    """
+    needs: dict[str, list[str]] = {}
+    minimums: dict[str, dict[str, str]] = {}
+    best: dict[str, dict[str, tuple[int, ...]]] = {}
+
+    try:
+        with Path(filename).open("rb") as f:
+            elf = ELFFile(f)
+            for section in elf.iter_sections():
+                if not isinstance(section, GNUVerNeedSection):
+                    continue
+                for verneed, aux_iter in section.iter_versions():
+                    libname = verneed.name
+                    for aux in aux_iter:
+                        version = aux.name
+                        needs.setdefault(libname, [])
+                        if version not in needs[libname]:
+                            needs[libname].append(version)
+                        prefix, numeric = _parse_symbol_version(version)
+                        if numeric is None:
+                            continue
+                        lib_best = best.setdefault(libname, {})
+                        if prefix not in lib_best or numeric > lib_best[prefix]:
+                            lib_best[prefix] = numeric
+    except (OSError, ELFError):
+        return {}
+
+    if not needs:
+        return {}
+
+    for libname, prefixes in best.items():
+        minimums[libname] = {
+            prefix: ".".join(str(n) for n in numeric)
+            for prefix, numeric in sorted(prefixes.items())
+        }
+
+    for versions in needs.values():
+        versions.sort()
+
+    return {
+        "minimumLibraryVersions": minimums,
+        "symbolVersionNeeds": needs,
+    }
+
+
+def _collect_sections(project: "angr.Project") -> list[dict[str, Any]]:
+    """Summarize the loaded sections (name, address, size, permissions)."""
+    main = project.loader.main_object
+    sections: list[dict[str, Any]] = []
+    for section in getattr(main, "sections", []) or []:
+        sections.append(
+            {
+                "name": getattr(section, "name", None),
+                "vaddr": _hex(getattr(section, "vaddr", None)),
+                "size": getattr(section, "memsize", None),
+                "isExecutable": bool(getattr(section, "is_executable", False)),
+                "isWritable": bool(getattr(section, "is_writable", False)),
+                "isReadable": bool(getattr(section, "is_readable", False)),
+            }
+        )
+    return sections
+
+
+@surfactant.plugin.hookimpl(specname="extract_file_info")
+def angr_expanded(sbom: SBOM, software: Software, filename: str, filetype: list[str]) -> object:
+    """Extract expanded angr binary analysis metadata for the SBOM.
+
+    Args:
+        sbom (SBOM): The SBOM the software entry belongs to.
+        software (Software): The software entry the metadata will be attached to.
+        filename (str): Full path to the file to analyze.
+        filetype (List[str]): File type hints based on magic bytes.
+
+    Returns:
+        object: A metadata dict stored under ``angrExpanded``, or None if the file
+            is not a supported binary or could not be loaded.
+    """
+    if not supports_file(filetype):
+        return None
+
+    path = Path(filename)
+    if not path.exists():
+        logger.warning(f"angr_expanded: file does not exist: {filename}")
+        return None
+
+    try:
+        project = angr.Project(path.as_posix(), auto_load_libs=False)
+    except (CLECompatibilityError, CLEError) as e:
+        logger.info(f"angr_expanded could not load {filename}: {e}")
+        return None
+    except Exception as e:  # noqa: BLE001 - loading untrusted binaries can raise anything
+        logger.warning(f"angr_expanded unexpected error loading {filename}: {e}")
+        return None
+
+    metadata: dict[str, Any] = {}
+    try:
+        metadata.update(_collect_loader_info(project))
+        metadata.update(_collect_symbols(project))
+        metadata.update(_collect_symbol_versions(path.as_posix()))
+        # ELF sections are already emitted by Surfactant's built-in elf_file
+        # extractor, so only add them here for formats it does not cover (PE,
+        # Mach-O). This keeps angr_expanded from duplicating the native ELF output.
+        if "ELF" not in filetype:
+            metadata["sections"] = _collect_sections(project)
+    except Exception as e:  # noqa: BLE001 - keep SBOM generation resilient
+        logger.warning(f"angr_expanded partial extraction for {filename}: {e}")
+
+    if not metadata:
+        return None
+
+    logger.info(f"angr_expanded extracted metadata for {path.name}")
+    return {_METADATA_KEY: metadata}
+
+
+# Cache mapping id(sbom) -> {export_symbol_name: set(software UUID)}. Exports do
+# not change during the relationship phase, so the index is built once per SBOM.
+_EXPORT_INDEX_CACHE: dict[int, dict[str, set[str]]] = {}
+
+
+def _iter_angr_metadata(software: Software) -> Any:
+    """Yield each ``angrExpanded`` metadata dict attached to a software entry."""
+    for entry in getattr(software, "metadata", None) or []:
+        if isinstance(entry, dict) and _METADATA_KEY in entry:
+            value = entry[_METADATA_KEY]
+            if isinstance(value, dict):
+                yield value
+
+
+def _build_export_index(sbom: SBOM) -> dict[str, set[str]]:
+    """Build (and cache) a map of exported function name -> set of exporter UUIDs."""
+    cached = _EXPORT_INDEX_CACHE.get(id(sbom))
+    if cached is not None:
+        return cached
+
+    index: dict[str, set[str]] = {}
+    for sw in getattr(sbom, "software", None) or []:
+        for md in _iter_angr_metadata(sw):
+            for exp in md.get("exportedFunctions", []):
+                name = exp.get("name") if isinstance(exp, dict) else None
+                if name:
+                    index.setdefault(name, set()).add(sw.UUID)
+    _EXPORT_INDEX_CACHE[id(sbom)] = index
+    return index
+
+
+def _basenames(paths: Any) -> set[str]:
+    """Return the set of lowercased basenames for a list of file names/paths."""
+    result: set[str] = set()
+    for p in paths or []:
+        if p:
+            result.add(Path(str(p)).name.lower())
+    return result
+
+
+@surfactant.plugin.hookimpl
+def establish_relationships(
+    sbom: SBOM, software: Software, metadata: object
+) -> list[Relationship] | None:
+    """Link a binary's imported functions to SBOM entries that export them.
+
+    For each imported function in this software's ``angrExpanded`` metadata, find
+    other software entries in the SBOM whose ``angrExpanded`` exports that symbol
+    and emit a ``Uses`` relationship. To keep matches high-confidence, when the
+    importer records ``linkedLibraries`` the exporter must also match one of those
+    library file names; otherwise a plain symbol match is used as a fallback.
+
+    Args:
+        sbom (SBOM): The SBOM being processed.
+        software (Software): The importing software entry.
+        metadata (object): One metadata value from the software entry; only the
+            ``angrExpanded`` value is handled.
+
+    Returns:
+        Optional[List[Relationship]]: ``Uses`` relationships, or None if this
+            metadata value is not an ``angrExpanded`` block with imports.
+    """
+    if not isinstance(metadata, dict) or _METADATA_KEY not in metadata:
+        return None
+    data = metadata[_METADATA_KEY]
+    if not isinstance(data, dict):
+        return None
+
+    imported = data.get("importedFunctions") or []
+    if not imported:
+        return None
+
+    export_index = _build_export_index(sbom)
+    if not export_index:
+        return None
+
+    linked_libs = _basenames(data.get("linkedLibraries"))
+
+    # Map candidate exporter UUID -> set of matched symbol names (for logging).
+    matches: dict[str, set[str]] = {}
+    for imp in imported:
+        name = imp.get("name") if isinstance(imp, dict) else None
+        if not name:
+            continue
+        for exporter_uuid in export_index.get(name, set()):
+            if exporter_uuid == software.UUID:
+                continue
+            if linked_libs:
+                exporter = (
+                    sbom.get_software(exporter_uuid) if hasattr(sbom, "get_software") else None
+                )
+                exporter = exporter or next(
+                    (s for s in (sbom.software or []) if s.UUID == exporter_uuid), None
+                )
+                if exporter is not None and not (_basenames(exporter.fileName) & linked_libs):
+                    continue
+            matches.setdefault(exporter_uuid, set()).add(name)
+
+    relationships: list[Relationship] = []
+    for exporter_uuid, symbols in matches.items():
+        relationships.append(
+            Relationship(xUUID=software.UUID, yUUID=exporter_uuid, relationship="Uses")
+        )
+        logger.debug(
+            f"angr_expanded: {software.UUID} Uses {exporter_uuid} ({len(symbols)} matched symbols)"
+        )
+
+    return relationships or None
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> str | None:
+    """Short name used to enable/disable and reference this plugin."""
+    return "angr_expanded"
+
+
+@surfactant.plugin.hookimpl
+def settings_name() -> str | None:
+    """Base name used for reading/writing this plugin's Surfactant settings."""
+    return _SETTINGS_SECTION

--- a/plugins/angr-expanded/surfactantplugin_angr_expanded.py
+++ b/plugins/angr-expanded/surfactantplugin_angr_expanded.py
@@ -30,6 +30,10 @@ from loguru import logger
 import surfactant.plugin
 from surfactant.sbomtypes import SBOM, Relationship, Software
 
+# Every ``except Exception`` below is intentional: analyzing a possibly-malformed or
+# untrusted binary must never abort SBOM generation for the rest of the corpus.
+# pylint: disable=broad-exception-caught
+
 # Top-level key the metadata object is stored under in the software entry.
 _METADATA_KEY = "angrExpanded"
 
@@ -375,7 +379,7 @@ def establish_relationships(
                 exporter = exporter or next(
                     (s for s in (sbom.software or []) if s.UUID == exporter_uuid), None
                 )
-                if exporter is not None and not (_basenames(exporter.fileName) & linked_libs):
+                if exporter is not None and not _basenames(exporter.fileName) & linked_libs:
                     continue
             matches.setdefault(exporter_uuid, set()).add(name)
 

--- a/plugins/binaryninja-info/README.md
+++ b/plugins/binaryninja-info/README.md
@@ -1,0 +1,97 @@
+# surfactantplugin-binaryninja-info
+
+A Surfactant plugin that uses **Binary Ninja** for lightweight *control-flow
+graph* extraction and embeds the results into the generated SBOM under the
+`binaryNinja` metadata key.
+
+It is designed to be **complementary** to the `angr_expanded` plugin, not
+overlapping. Each tool focuses on what it does best:
+
+| Concern | Owned by | Why |
+|---------|----------|-----|
+| Loader/architecture, PIC, sections | `angr_expanded` (angr/CLE) | angr's loader is fast and authoritative |
+| Imported/exported symbols | `angr_expanded` | drives dependency resolution |
+| Import → library resolution, `Uses` relationships | `angr_expanded` | CLE resolves providers |
+| Minimum library versions (CVE matching) | `angr_expanded` | pyelftools version-needs |
+| **Function inventory (accurate recovery)** | **`binaryninja_info`** | BN recovers more/cleaner functions on stripped code |
+| **Per-function control-flow graph (blocks + edges)** | **`binaryninja_info`** | BN's CFG recovery is high fidelity and cheap in `controlFlow` mode |
+
+The binary is always loaded in Binary Ninja's **`controlFlow`** analysis mode, so
+only function and basic-block recovery runs — the heavier data-flow / IL /
+decompilation passes are skipped. This keeps the plugin fast and its output
+scoped to the one thing Binary Ninja does best.
+
+## Metadata schema (`binaryNinja`)
+
+```jsonc
+{
+  "coreVersion": "5.3.9757",
+  "platform": "linux-aarch64",   // BN OS/ABI concept (arch/endianness/entryPoint
+                                  // are owned by angrExpanded, not repeated here)
+  "functionCount": 1234,          // over ALL functions
+  "basicBlockCount": 9876,
+  "instructionCount": 54321,
+  "thunkCount": 42,
+  "emittedFunctionCount": 611,    // functions actually in functions[] (post-filter)
+  "controlFlowTruncated": false,  // true if functions[] was capped by max_functions
+  "functions": [                  // capped at max_functions; excludes thunks,
+                                  // clones, library funcs, and < min_basic_blocks
+    {
+      "name": "main",
+      "address": "0x...",
+      "basicBlockCount": 12,
+      "instructionCount": 130,
+      "isThunk": false,
+      "basicBlocks": [            // structure only, no disassembly text
+        {"start": "0x...", "end": "0x...", "instructionCount": 8,
+         "edges": [{"target": "0x...", "type": "TrueBranch"},
+                   {"target": "0x...", "type": "FalseBranch"}]}
+      ]
+    }
+  ]
+}
+```
+
+## Settings
+
+Read via Surfactant's `ConfigManager`, section `binary_ninja`:
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `max_functions` | `5000` | Cap on emitted `functions[]` / analyzed-function count |
+| `min_basic_blocks` | `2` | Minimum blocks for a function to appear in `functions[]`; set to `1` to emit every function (incl. straight-line stubs) |
+| `exclude_library_functions` | `true` | Drop C++ runtime/library functions (`std::`, `__gnu_cxx::`, `fmt::`, `spdlog::`, `cxxopts::`, `nlohmann::`) from `functions[]`; set to `false` to include them |
+
+Aggregate statistics (`functionCount`, etc.) are always computed over **all**
+functions regardless of `max_functions`, `min_basic_blocks`, and
+`exclude_library_functions`. To cut bloat, the emitted `functions[]` CFG excludes
+thunks, functions with no real control flow (fewer than `min_basic_blocks` basic
+blocks), compiler-generated clones (`.cold`/`.isra`/`.constprop`/`.part`), and —
+unless disabled — C++ runtime/library functions matched by mangled or demangled
+name prefix. Those stubs and library internals otherwise dominate the output.
+
+## How it works
+
+1. `supports_file` limits analysis to `ELF`, `PE`, `MACHO`, `MACHOFAT`. For ELF,
+   an additional `e_type` check restricts analysis to **true loadable
+   executables** — `ET_EXEC` and `ET_DYN` (shared objects / PIE) — and
+   **excludes** `ET_REL` relocatable objects, which is what Linux kernel modules
+   (`.ko`) and `.o` files are, as well as core dumps.
+2. Binary Ninja is imported **lazily**. If the API is not importable (not on
+   `sys.path`, unlicensed, etc.) the plugin logs a warning and skips — SBOM
+   generation is never blocked.
+3. `binaryninja.load(path, options={"analysis.mode": "controlFlow"})` produces
+   the `BinaryView`. The plugin walks `view.functions` once to build the
+   aggregate stats and the filtered per-function CFG.
+
+## Environment
+
+The Binary Ninja Python API and a valid license must be available to the Python
+interpreter running Surfactant. Typical options:
+
+- Run Binary Ninja's `scripts/install_api.py` once to drop a `.pth` into the
+  active environment, **or**
+- Add the API directory to `PYTHONPATH` (e.g.
+  `.../binaryninja/python`).
+
+No environment setup is performed by this plugin.

--- a/plugins/binaryninja-info/pyproject.toml
+++ b/plugins/binaryninja-info/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "surfactantplugin-binaryninja-info"
+version = "0.1.0"
+authors = [
+    {name = "Benton Wilson", email = "bwilson@nlr.gov"},
+]
+description = "Surfactant plugin providing Binary Ninja structural code analysis metadata"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["surfactant", "binaryninja", "sbom", "binary-analysis"]
+license = "MIT"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+]
+# Binary Ninja is a licensed, out-of-tree Python API and is intentionally not a
+# hard dependency: the plugin imports it lazily and skips analysis if absent.
+dependencies = [
+    "surfactant",
+]
+
+[project.entry-points."surfactant"]
+"surfactantplugin_binaryninja_info" = "surfactantplugin_binaryninja_info"
+
+[tool.setuptools]
+py-modules = ["surfactantplugin_binaryninja_info"]

--- a/plugins/binaryninja-info/surfactantplugin_binaryninja_info.py
+++ b/plugins/binaryninja-info/surfactantplugin_binaryninja_info.py
@@ -1,0 +1,358 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC
+# See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+"""Surfactant plugin that uses Binary Ninja for control-flow graph extraction.
+
+This plugin is intentionally scoped to the one thing Binary Ninja does *better*
+than angr: high-fidelity function recovery and the per-function control-flow
+graph (basic blocks + edges). It loads the binary in Binary Ninja's
+``controlFlow`` analysis mode, which recovers functions and CFGs without running
+the far more expensive data-flow / IL / decompilation passes.
+
+It deliberately does **not** duplicate the loader/symbol/dependency work owned by
+the ``angr_expanded`` plugin, so the two produce complementary (not overlapping)
+records on the same binary. The metadata is grouped under the ``binaryNinja`` key.
+
+Because the Binary Ninja Python API usually lives outside ``site-packages`` and
+requires a license, it is imported lazily. If it cannot be imported the plugin
+registers but simply skips analysis (logging a warning), so SBOM generation is
+never blocked by a missing Binary Ninja install.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+import surfactant.plugin
+from surfactant.configmanager import ConfigManager
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime here
+    import binaryninja as bn
+
+    from surfactant.sbomtypes import SBOM, Software
+
+# Top-level key the metadata object is stored under in the software entry.
+_METADATA_KEY = "binaryNinja"
+
+# Settings section and keys (read via Surfactant's ConfigManager).
+_SETTINGS_SECTION = "binary_ninja"
+_SETTINGS_MAX_FUNCTIONS = "max_functions"
+_SETTINGS_MIN_BASIC_BLOCKS = "min_basic_blocks"
+_SETTINGS_EXCLUDE_LIBRARY = "exclude_library_functions"
+
+# Cap on how many per-function records are emitted so a single large binary
+# (e.g. a statically-linked busybox with thousands of functions) cannot bloat
+# the SBOM without bound. Aggregate statistics are always computed over *all*
+# functions regardless of this cap.
+_DEFAULT_MAX_FUNCTIONS = 5000
+
+# Minimum basic-block count for a function to be emitted in the CFG ``functions``
+# list. A single-block function has no control flow worth serializing, and such
+# stubs (PLT thunks, trivial wrappers) otherwise dominate the output. They are
+# still counted in the aggregate stats. Set to 1 to emit every function.
+_DEFAULT_MIN_BASIC_BLOCKS = 2
+
+# GCC/Clang emit helper "clones" — cold-path splits and interprocedural
+# specializations — whose standalone CFG carries little analytic value and which
+# heavily inflate the output. They are excluded from the emitted ``functions``
+# list (still counted in aggregate stats). Matched as substrings of the name.
+_CLONE_MARKERS = (".cold", ".isra", ".constprop", ".part")
+
+# C++ runtime/library namespaces whose functions are rarely the analysis target
+# and which dominate the CFG of any C++ binary. When library exclusion is on
+# (default), functions whose name starts with one of these markers are dropped
+# from the emitted ``functions`` list (still counted in aggregate stats). Both
+# Itanium-mangled prefixes (e.g. ``_ZNSt`` for ``std::``) and demangled
+# ``namespace::`` prefixes are matched so it works regardless of BN's naming.
+_DEFAULT_LIBRARY_MARKERS = (
+    "_ZNSt",  # std:: (nested)
+    "_ZSt",  # std:: (free function)
+    "_ZNKSt",  # std:: (const method)
+    "_ZN9__gnu_cxx",  # __gnu_cxx::
+    "_ZN3fmt",  # fmt::
+    "_ZN6spdlog",  # spdlog::
+    "_ZN7cxxopts",  # cxxopts::
+    "_ZN8nlohmann",  # nlohmann::
+    "std::",
+    "__gnu_cxx::",
+    "fmt::",
+    "spdlog::",
+    "cxxopts::",
+    "nlohmann::",
+)
+
+
+def supports_file(filetype: list[str]) -> bool:
+    """Return True for executable formats Binary Ninja can load."""
+    return any(t in filetype for t in ("ELF", "PE", "MACHOFAT", "MACHO"))
+
+
+# ELF ``e_type`` values kept for analysis: ET_EXEC (executables) and ET_DYN
+# (shared objects / PIE executables). ET_REL (relocatable objects, which is what
+# Linux kernel modules ``.ko`` and ``.o`` files are) and ET_CORE are excluded so
+# Binary Ninja only analyzes true loadable executables/libraries.
+_ELF_ANALYZABLE_ETYPES = frozenset({2, 3})  # ET_EXEC, ET_DYN
+
+
+def _is_true_executable(path: Path, filetype: list[str]) -> bool:
+    """Return True only for genuine loadable binaries.
+
+    For ELF, this reads ``e_type`` and rejects relocatable objects (``.ko``
+    kernel modules, ``.o`` files) and core dumps. Non-ELF supported formats
+    (PE, Mach-O) are executables/dylibs already and are allowed through.
+    """
+    if "ELF" not in filetype:
+        return True
+    try:
+        with path.open("rb") as f:
+            header = f.read(18)
+    except OSError:
+        return False
+    if len(header) < 18 or header[:4] != b"\x7fELF":
+        return False
+    # EI_DATA (byte 5): 1 = little-endian, 2 = big-endian.
+    endian = "big" if header[5] == 2 else "little"
+    e_type = int.from_bytes(header[16:18], endian)
+    return e_type in _ELF_ANALYZABLE_ETYPES
+
+
+def _get_bool_setting(key: str, default: bool) -> bool:
+    """Read a boolean plugin setting, never raising on lookup failure."""
+    try:
+        return bool(ConfigManager().get(_SETTINGS_SECTION, key, default))
+    except Exception:  # noqa: BLE001 - config lookup must never break extraction
+        return default
+
+
+def _get_int_setting(key: str, default: int) -> int:
+    """Read an integer plugin setting, never raising on lookup failure."""
+    try:
+        value = ConfigManager().get(_SETTINGS_SECTION, key, default)
+        return int(value)
+    except Exception:  # noqa: BLE001 - config lookup must never break extraction
+        return default
+
+
+def _load_binaryninja() -> bn | None:
+    """Import the Binary Ninja API lazily; return the module or None."""
+    try:
+        import binaryninja as bn  # noqa: PLC0415 - intentional lazy import
+    except Exception as e:  # noqa: BLE001 - missing/broken install must not crash
+        logger.warning(
+            "binaryninja_info: Binary Ninja Python API not importable "
+            f"({type(e).__name__}: {e}); skipping structural analysis"
+        )
+        return None
+    return bn
+
+
+def _open_view(bn: bn, path: str) -> Any | None:
+    """Open an analyzed BinaryView for ``path`` (headless) in ``controlFlow`` mode.
+
+    ``controlFlow`` recovers only functions and basic blocks, which is all the
+    CFG extraction needs -- it skips the far more expensive data-flow / IL /
+    decompilation passes.
+    """
+    try:
+        view = bn.load(path, options={"analysis.mode": "controlFlow"})
+    except Exception as e:  # noqa: BLE001 - loading untrusted binaries can raise anything
+        logger.info(f"binaryninja_info could not load {path}: {e}")
+        return None
+    if view is None:
+        return None
+    try:
+        # ``load`` normally runs analysis already; this is a cheap no-op if so and
+        # guarantees the CFG is populated before we read it.
+        view.update_analysis_and_wait()
+    except Exception as e:  # noqa: BLE001 - analysis can fail on malformed input
+        logger.warning(f"binaryninja_info analysis incomplete for {path}: {e}")
+    return view
+
+
+def _collect_header(bn: bn, view: Any) -> dict[str, Any]:
+    """Collect BN-unique provenance/platform header fields.
+
+    Loader facts that angr already owns (``arch``, ``endianness``, ``entryPoint``,
+    ``objectFormat``, image base, sections, ...) are intentionally *not* repeated
+    here to keep the two plugins non-redundant. ``platform`` is kept because it is
+    a Binary Ninja concept that folds in the OS/ABI dimension angr does not report
+    (e.g. ``linux-aarch64``).
+    """
+    platform = getattr(view, "platform", None)
+    return {
+        "coreVersion": bn.core_version(),
+        "platform": getattr(platform, "name", None),
+    }
+
+
+def _basic_block_record(block: Any) -> dict[str, Any]:
+    """Build a structure-only record for one basic block (no disassembly text)."""
+    edges: list[dict[str, str]] = []
+    for edge in getattr(block, "outgoing_edges", []):
+        target = getattr(edge, "target", None)
+        if target is None:
+            continue
+        edges.append(
+            {
+                "target": hex(target.start),
+                "type": getattr(edge.type, "name", str(edge.type)),
+            }
+        )
+    return {
+        "start": hex(block.start),
+        "end": hex(block.end),
+        "instructionCount": getattr(block, "instruction_count", 0),
+        "edges": edges,
+    }
+
+
+def _iter_control_flow(
+    view: Any, limit: int, min_basic_blocks: int, library_markers: tuple = ()
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Single pass over functions: build a filtered CFG list + full-corpus stats.
+
+    Returns ``(functions, stats)``. ``functions`` holds compact per-function
+    control-flow records (basic blocks + edges), excluding thunks, functions
+    with fewer than ``min_basic_blocks`` blocks (which carry no control flow),
+    compiler-generated clones, and — when ``library_markers`` is non-empty —
+    functions whose name starts with a C++ runtime/library marker. Records are
+    capped at ``limit``. ``stats`` aggregates over *every* recovered function
+    regardless of those filters.
+    """
+    functions: list[dict[str, Any]] = []
+    total_functions = 0
+    total_basic_blocks = 0
+    total_instructions = 0
+    thunk_count = 0
+    capped = False
+
+    for func in view.functions:
+        total_functions += 1
+        basic_blocks = func.basic_blocks
+        bb_count = len(basic_blocks)
+        insn_count = 0
+        for block in basic_blocks:
+            insn_count += getattr(block, "instruction_count", 0)
+        total_basic_blocks += bb_count
+        total_instructions += insn_count
+
+        is_thunk = bool(getattr(func, "is_thunk", False))
+        if is_thunk:
+            thunk_count += 1
+
+        # Drop analytically-empty or off-target records to cut bloat: thunks
+        # (pure forwarders), compiler-generated clones, functions with no real
+        # control flow, and — when enabled — C++ runtime/library functions. All
+        # are still counted in the aggregate stats above.
+        name = func.name
+        if (
+            is_thunk
+            or bb_count < min_basic_blocks
+            or any(marker in name for marker in _CLONE_MARKERS)
+            or any(name.startswith(prefix) for prefix in library_markers)
+        ):
+            continue
+        if len(functions) >= limit:
+            capped = True
+            continue
+
+        functions.append(
+            {
+                "name": func.name,
+                "address": hex(func.start),
+                "basicBlockCount": bb_count,
+                "instructionCount": insn_count,
+                "isThunk": is_thunk,
+                "basicBlocks": [_basic_block_record(block) for block in basic_blocks],
+            }
+        )
+
+    stats = {
+        "functionCount": total_functions,
+        "basicBlockCount": total_basic_blocks,
+        "instructionCount": total_instructions,
+        "thunkCount": thunk_count,
+        "emittedFunctionCount": len(functions),
+        "controlFlowTruncated": capped,
+    }
+    return functions, stats
+
+
+@surfactant.plugin.hookimpl(specname="extract_file_info")
+def binaryninja_info(sbom: SBOM, software: Software, filename: str, filetype: list[str]) -> object:
+    """Extract Binary Ninja control-flow-graph metadata for the SBOM.
+
+    Args:
+        sbom (SBOM): The SBOM the software entry belongs to.
+        software (Software): The software entry the metadata will be attached to.
+        filename (str): Full path to the file to analyze.
+        filetype (List[str]): File type hints based on magic bytes.
+
+    Returns:
+        object: A metadata dict stored under ``binaryNinja``, or None if the file
+            is unsupported or Binary Ninja could not analyze it.
+    """
+    if not supports_file(filetype):
+        return None
+
+    path = Path(filename)
+    if not path.exists():
+        logger.warning(f"binaryninja_info: file does not exist: {filename}")
+        return None
+
+    if not _is_true_executable(path, filetype):
+        logger.info(
+            "binaryninja_info: skipping non-executable ELF "
+            f"(relocatable object / kernel module / core): {path.name}"
+        )
+        return None
+
+    bn = _load_binaryninja()
+    if bn is None:
+        return None
+
+    view = _open_view(bn, path.as_posix())
+    if view is None:
+        return None
+
+    max_functions = _get_int_setting(_SETTINGS_MAX_FUNCTIONS, _DEFAULT_MAX_FUNCTIONS)
+    min_basic_blocks = _get_int_setting(_SETTINGS_MIN_BASIC_BLOCKS, _DEFAULT_MIN_BASIC_BLOCKS)
+    library_markers = (
+        _DEFAULT_LIBRARY_MARKERS if _get_bool_setting(_SETTINGS_EXCLUDE_LIBRARY, True) else ()
+    )
+    metadata: dict[str, Any] = {}
+    try:
+        metadata.update(_collect_header(bn, view))
+        functions, stats = _iter_control_flow(
+            view, max_functions, min_basic_blocks, library_markers
+        )
+        metadata.update(stats)
+        metadata["functions"] = functions
+    except Exception as e:  # noqa: BLE001 - keep SBOM generation resilient
+        logger.warning(f"binaryninja_info partial extraction for {filename}: {e}")
+    finally:
+        with contextlib.suppress(Exception):  # best-effort cleanup
+            view.file.close()
+
+    if not metadata:
+        return None
+
+    logger.info(f"binaryninja_info extracted metadata for {path.name}")
+    return {_METADATA_KEY: metadata}
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> str | None:
+    """Short name used to enable/disable and reference this plugin."""
+    return "binaryninja_info"
+
+
+@surfactant.plugin.hookimpl
+def settings_name() -> str | None:
+    """Base name used for reading/writing this plugin's Surfactant settings."""
+    return _SETTINGS_SECTION

--- a/plugins/binaryninja-info/surfactantplugin_binaryninja_info.py
+++ b/plugins/binaryninja-info/surfactantplugin_binaryninja_info.py
@@ -36,6 +36,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only, never imported at runtime h
 
     from surfactant.sbomtypes import SBOM, Software
 
+# ``except Exception`` guards and the lazy Binary Ninja import below are intentional:
+# a missing/unlicensed install or a malformed binary must never abort SBOM generation.
+# pylint: disable=broad-exception-caught,import-outside-toplevel
+
 # Top-level key the metadata object is stored under in the software entry.
 _METADATA_KEY = "binaryNinja"
 
@@ -297,6 +301,7 @@ def binaryninja_info(sbom: SBOM, software: Software, filename: str, filetype: li
         object: A metadata dict stored under ``binaryNinja``, or None if the file
             is unsupported or Binary Ninja could not analyze it.
     """
+    # pylint: disable=too-many-return-statements
     if not supports_file(filetype):
         return None
 

--- a/plugins/binwalk-carver/README.md
+++ b/plugins/binwalk-carver/README.md
@@ -1,0 +1,85 @@
+# surfactant-plugin-binwalk-carver
+
+A vendor-agnostic Surfactant plugin that uses [binwalk](https://github.com/ReFirmLabs/binwalk)
+to carve embedded regions out of a file and feed each one back into the Surfactant
+processing pipeline.
+
+## Why
+
+Surfactant's built-in decompressor and the OFRAK unpacker only recognize a format
+when its magic bytes sit at a **fixed offset** (usually 0). Real firmware images
+are frequently proprietary outer containers -- vendor headers, padding, and
+concatenated blobs -- that wrap standard artifacts (an LZMA kernel, a
+SquashFS/JFFS2/UBIFS root filesystem, etc.) at **arbitrary, non-zero offsets**. A
+filesystem that starts partway into the image is therefore never seen.
+
+For example, a TP-Link OpenWrt `factory.bin` starts with a TP-Link header at
+offset 0 and places the SquashFS root filesystem at offset `0x1102FC`. Nothing in
+the default pipeline detects it.
+
+## What it does
+
+1. Runs a `binwalk` signature scan (JSON output, no extraction) on each file.
+2. Turns every region binwalk recognizes at a **non-zero offset** into a concrete
+   byte range.
+3. Carves each such region into a standalone file in a temp directory.
+4. Pushes a `ContextEntry` for each carved file onto Surfactant's `context_queue`.
+
+Each carved region then re-enters the **entire** plugin pipeline. Because its
+magic now sits at offset 0 of the carved file, the native extractors, the
+file-decompression plugin, and the OFRAK unpacker identify and process it exactly
+as they would a stand-alone artifact.
+
+The plugin only *carves*; it never analyzes contents itself and does not use
+binwalk's own extraction (`-e`). **OFRAK (`ofrak_unpacker`) and the built-in
+decompressor are the primary extractors** — this plugin exists only to expose the
+embedded artifacts they cannot see because those artifacts don't start at offset 0.
+
+### Scope / duplication safety
+
+- **Only non-zero-offset regions are carved.** Anything whose magic is at offset
+  0 is already visible to OFRAK and the native identifiers, so it is left to them
+  — this is what keeps the carver from duplicating OFRAK's work or re-copying a
+  carved filesystem forever.
+- **Files Surfactant analyzes natively are skipped** (`ELF`, `PE`, `MACHO32`,
+  `MACHO64`, `MACHOFAT`). Carving a standalone executable only produces truncated,
+  unparseable fragments; the carver is meant for outer firmware images.
+- **ELF signatures are never carved**, even inside an image — the filesystem
+  unpacker recovers the ELF and it is then analyzed directly.
+- Results are de-duplicated by SHA-256, so identical bytes are only carved once.
+- Files already being processed as a container's contents are skipped.
+
+## Requirements
+
+- The `binwalk` executable must be on `PATH`. If it is missing, the plugin logs a
+  warning once and does nothing (SBOM generation still succeeds).
+- Install binwalk via `cargo install binwalk` (v3, Rust) or `pip install binwalk`.
+
+## Install
+
+```bash
+pip install -e plugins/binwalk-carver
+```
+
+## Configuration
+
+Settings live under the `[binwalk_carver]` section of the Surfactant config
+(`surfactant config` / `~/.config/surfactant/config.toml`):
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `binwalk_path` | `binwalk` | Name or path of the binwalk executable. |
+| `extract_dir` | system temp | Base directory for carved output. |
+| `min_file_size` | `4096` | Files smaller than this are not scanned. |
+| `min_carve_size` | `512` | Regions smaller than this are not carved. |
+| `search_all` | `false` | Pass `-a` to binwalk (search all signatures at all offsets). |
+| `exclude_signatures` | `[]` | binwalk signature names to skip (passed as `-x`). |
+| `timeout` | `300` | Per-file binwalk timeout, in seconds. |
+
+## Usage
+
+Once installed it runs automatically during `surfactant generate`:
+
+```bash
+surfactant generate firmware.bin out.json
+```

--- a/plugins/binwalk-carver/pyproject.toml
+++ b/plugins/binwalk-carver/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "surfactantplugin-binwalk-carver"
+version = "0.1.0"
+authors = [
+    {name = "Benton Wilson", email = "bwilson@nlr.gov"},
+]
+description = "Surfactant plugin that carves embedded regions out of files with binwalk and feeds them back into the pipeline"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["surfactant", "binwalk", "sbom", "firmware", "carving", "unpacking"]
+license = "MIT"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Operating System :: POSIX :: Linux",
+]
+dependencies = [
+    "surfactant",
+]
+
+[project.entry-points."surfactant"]
+"surfactantplugin_binwalk_carver" = "surfactantplugin_binwalk_carver"
+
+[tool.setuptools]
+py-modules = ["surfactantplugin_binwalk_carver"]

--- a/plugins/binwalk-carver/surfactantplugin_binwalk_carver.py
+++ b/plugins/binwalk-carver/surfactantplugin_binwalk_carver.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: MIT
+"""Surfactant plugin that carves regions embedded at non-zero offsets with binwalk.
+
+The OFRAK unpacker (``ofrak_unpacker``) and Surfactant's built-in decompressor are
+the primary extractors: they identify a container/filesystem by the magic bytes at
+offset 0 and unpack it properly. What they cannot see is an artifact embedded
+*partway* into an opaque blob -- a vendor-headered firmware image that wraps an
+LZMA kernel at one offset and a SquashFS root filesystem at another, none of whose
+magic sits at offset 0.
+
+That gap is the only thing this plugin fills. It shells out to ``binwalk`` (the
+signature scanner) to locate embedded regions, carves each region that starts at a
+**non-zero** offset into its own file (so its magic now sits at offset 0), and
+pushes a ``ContextEntry`` for it onto Surfactant's ``context_queue``. Each carved
+region then re-enters the pipeline where OFRAK / the native decompressor identify
+and unpack it exactly as they would a stand-alone artifact.
+
+The plugin only carves; it never analyzes contents and never unpacks. Regions at
+offset 0, files Surfactant already analyzes natively (ELF/PE/Mach-O), and embedded
+ELF signatures are all skipped -- those are handled directly by OFRAK and the
+native extractors, so carving them only duplicates work (and produces truncated
+fragments). binwalk is an optional runtime dependency: if it is not on PATH the
+plugin logs a warning once and does nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import subprocess
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+import surfactant.plugin
+from surfactant import ContextEntry
+from surfactant.configmanager import ConfigManager
+from surfactant.sbomtypes import Software
+
+if TYPE_CHECKING:
+    from queue import Queue
+
+    from surfactant.sbomtypes import Software
+
+_METADATA_KEY = "binwalkCarver"
+_SETTINGS_SECTION = "binwalk_carver"
+
+# File types that Surfactant already analyzes natively (via their own info
+# extractors), so the carver must never scan or carve them. These are standalone
+# executables/objects -- not firmware containers -- and running binwalk on them
+# only produces truncated, unparseable fragments (e.g. a carved ELF whose section
+# table points past the end of the carved bytes). The carver is meant for outer
+# firmware images (.img, etc.) that wrap filesystems, not for artifacts that can
+# be parsed directly.
+_SKIP_INPUT_FILETYPES = frozenset({"ELF", "PE", "MACHOFAT", "MACHO32", "MACHO64"})
+
+# binwalk signature names that must never be carved into standalone files. An ELF
+# embedded in a firmware image is recovered by the filesystem unpacker and then
+# analyzed directly, so carving its raw signature only yields truncated fragments.
+_NON_CARVE_SIGNATURES = frozenset({"elf"})
+
+# Map binwalk signature names (the lowercase ``name`` field in its file_map) to a
+# standard file extension so carved regions are named like the artifact they are.
+# Some downstream plugins (and the built-in file_decompression / extension
+# identifier) key off the extension. Names not listed fall back to ``.bin``.
+_EXTENSION_MAP: dict[str, str] = {
+    # Archives / compression streams
+    "gzip": ".gz",
+    "bzip2": ".bz2",
+    "xz": ".xz",
+    "lzma": ".lzma",
+    "lzop": ".lzo",
+    "zstd": ".zst",
+    "tarball": ".tar",
+    "tar": ".tar",
+    "sevenzip": ".7z",
+    "7z": ".7z",
+    "rar": ".rar",
+    "cpio": ".cpio",
+    # Filesystems
+    "squashfs": ".squashfs",
+    "cramfs": ".cramfs",
+    "jffs2": ".jffs2",
+    "ubi": ".ubi",
+    "ubifs": ".ubifs",
+    "yaffs": ".yaffs",
+    "romfs": ".romfs",
+    "ext": ".ext",
+    "iso9660": ".iso",
+    # Firmware / boot containers
+    "uimage": ".uimage",
+    "trx": ".trx",
+    "dtb": ".dtb",
+    "uefi": ".fv",
+}
+
+
+def _extension_for(name: str) -> str:
+    """Return the standard file extension for a binwalk signature name."""
+    return _EXTENSION_MAP.get(name.lower(), ".bin")
+
+
+# sha256 -> carve output directory, so identical bytes are only carved once.
+# Directories are intentionally kept (not auto-deleted) so their contents can be
+# inspected and reused, mirroring Surfactant's built-in file_decompression.
+_CARVE_DIRS: dict[str, str] = {}
+
+
+def _get(key: str, default: Any) -> Any:
+    return ConfigManager().get(_SETTINGS_SECTION, key, default)
+
+
+def _binwalk_path() -> str | None:
+    configured = _get("binwalk_path", "binwalk")
+    return shutil.which(configured)
+
+
+def _make_carve_dir() -> str:
+    base = _get("extract_dir", tempfile.gettempdir())
+    pathlib.Path(base).mkdir(parents=True, exist_ok=True)
+    return tempfile.mkdtemp(prefix="surfactant-binwalk-", dir=base)
+
+
+def _run_binwalk(filepath: str) -> list[dict[str, Any]]:
+    """Run a binwalk signature scan and return its ``file_map`` entries.
+
+    Uses binwalk's JSON log output (``-l``) with stdout suppressed (``-q``) and
+    performs no extraction. Returns an empty list on any failure so a single bad
+    scan never aborts SBOM generation.
+    """
+    binwalk = _binwalk_path()
+    if binwalk is None:
+        return []
+
+    timeout = int(_get("timeout", 300))
+    search_all = bool(_get("search_all", False))
+    exclude = _get("exclude_signatures", [])
+
+    with tempfile.TemporaryDirectory(prefix="surfactant-binwalk-log-") as log_dir:
+        log_path = str(pathlib.Path(log_dir) / "binwalk.json")
+        cmd = [binwalk, "-q", "-l", log_path]
+        if search_all:
+            cmd.append("-a")
+        if exclude:
+            for sig in exclude:
+                cmd += ["-x", str(sig)]
+        cmd.append(filepath)
+
+        try:
+            subprocess.run(  # noqa: S603 - args are built from config + a file path
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=timeout,
+                check=False,
+            )
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning(f"binwalk scan of {filepath} failed: {exc}")
+            return []
+
+        try:
+            with pathlib.Path(log_path).open(encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return []
+
+    entries: list[dict[str, Any]] = []
+    if isinstance(data, list):
+        for top in data:
+            if isinstance(top, dict):
+                analysis = top.get("Analysis", {})
+                file_map = analysis.get("file_map", []) if isinstance(analysis, dict) else []
+                if isinstance(file_map, list):
+                    entries.extend(e for e in file_map if isinstance(e, dict))
+    return entries
+
+
+def _compute_carve_regions(
+    entries: list[dict[str, Any]], file_size: int, min_carve_size: int
+) -> list[dict[str, Any]]:
+    """Turn binwalk ``file_map`` entries into concrete byte ranges to carve.
+
+    Only regions embedded at a **non-zero** offset are carved: anything at offset 0
+    has its magic where OFRAK and the native identifiers already look, so they
+    handle it directly (this is what keeps the carver from duplicating OFRAK's
+    work and from re-carving a file that is already the artifact). When binwalk
+    reports no size for a signature, the region is extended to the next
+    signature's offset (or end of file). Signatures Surfactant analyzes natively
+    (e.g. ELF) are skipped.
+    """
+    ordered = sorted(
+        (e for e in entries if isinstance(e.get("offset"), int)),
+        key=lambda e: e["offset"],
+    )
+
+    regions: list[dict[str, Any]] = []
+    for i, entry in enumerate(ordered):
+        name = str(entry.get("name", "data"))
+        if name.lower() in _NON_CARVE_SIGNATURES:
+            continue
+
+        offset = int(entry["offset"])
+        # Skip offset-0 (and invalid) regions; OFRAK / native identifiers own those.
+        if offset <= 0 or offset >= file_size:
+            continue
+
+        size = entry.get("size")
+        if not isinstance(size, int) or size <= 0:
+            next_offset = int(ordered[i + 1]["offset"]) if i + 1 < len(ordered) else file_size
+            size = max(next_offset - offset, 0)
+
+        end = min(offset + size, file_size)
+        length = end - offset
+        if length < min_carve_size:
+            continue
+
+        regions.append(
+            {
+                "offset": offset,
+                "length": length,
+                "name": name,
+                "description": str(entry.get("description", "")),
+            }
+        )
+    return regions
+
+
+def _carve_range(src_path: str, offset: int, length: int, dest_path: str) -> int:
+    """Copy ``length`` bytes starting at ``offset`` from ``src_path`` to ``dest_path``."""
+    written = 0
+    with pathlib.Path(src_path).open("rb") as src, pathlib.Path(dest_path).open("wb") as out:
+        src.seek(offset)
+        remaining = length
+        while remaining > 0:
+            chunk = src.read(min(1 << 20, remaining))
+            if not chunk:
+                break
+            out.write(chunk)
+            written += len(chunk)
+            remaining -= len(chunk)
+    return written
+
+
+def _existing_carved_files(out_dir: str) -> list[str]:
+    return [str(p) for p in sorted(pathlib.Path(out_dir).glob("carved_*")) if p.is_file()]
+
+
+# pylint: disable-next=too-many-positional-arguments
+@surfactant.plugin.hookimpl
+def extract_file_info(
+    software: Software,
+    filename: str,
+    filetype: list[str],
+    context_queue: Queue[ContextEntry],
+    current_context: ContextEntry | None,
+    omit_unrecognized_types: bool = False,
+) -> dict[str, Any] | None:
+    """Carve non-zero-offset embedded regions out of ``filename`` and queue them."""
+    if _binwalk_path() is None:
+        return None
+
+    # Skip files Surfactant already analyzes natively (ELF/PE/Mach-O). Carving
+    # these only yields truncated fragments; the carver is for firmware images.
+    if filetype and any(ft in _SKIP_INPUT_FILETYPES for ft in filetype):
+        return None
+
+    # Don't scan files too small to plausibly contain an embedded filesystem.
+    min_file_size = int(_get("min_file_size", 4096))
+    try:
+        file_size = pathlib.Path(filename).stat().st_size
+    except OSError:
+        return None
+    if file_size < min_file_size:
+        return None
+
+    # Avoid re-carving a container we're already processing the contents of.
+    if current_context and current_context.archive == filename and current_context.extractPaths:
+        return None
+
+    install_prefix = current_context.installPrefix if current_context else ""
+
+    # Reuse a previous carve of identical bytes.
+    out_dir = _CARVE_DIRS.get(software.sha256)
+    reused = bool(out_dir and pathlib.Path(out_dir).exists())
+
+    if reused:
+        carved_files = _existing_carved_files(out_dir)
+        if not carved_files:
+            return None
+        for path in carved_files:
+            context_queue.put(
+                ContextEntry(
+                    archive=filename,
+                    installPrefix=install_prefix,
+                    extractPaths=[path],
+                    skipProcessingArchive=True,
+                    omitUnrecognizedTypes=omit_unrecognized_types,
+                )
+            )
+        return {
+            _METADATA_KEY: {
+                "carved": True,
+                "cached": True,
+                "extractPath": out_dir,
+                "regionCount": len(carved_files),
+            }
+        }
+
+    entries = _run_binwalk(filename)
+    if not entries:
+        return None
+
+    min_carve_size = int(_get("min_carve_size", 512))
+    regions = _compute_carve_regions(entries, file_size, min_carve_size)
+    if not regions:
+        return None
+    regions.sort(key=lambda r: r["offset"])
+
+    out_dir = _make_carve_dir()
+    _CARVE_DIRS[software.sha256] = out_dir
+
+    carved: list[dict[str, Any]] = []
+    for idx, region in enumerate(regions):
+        ext = _extension_for(region["name"])
+        dest = str(
+            pathlib.Path(out_dir)
+            / f"carved_{idx:03d}_0x{region['offset']:08x}_{region['name']}{ext}"
+        )
+        try:
+            written = _carve_range(filename, region["offset"], region["length"], dest)
+        except OSError as exc:
+            logger.warning(f"Failed to carve region at 0x{region['offset']:x} of {filename}: {exc}")
+            continue
+        if written <= 0:
+            continue
+
+        carved.append(
+            {
+                "offset": region["offset"],
+                "length": written,
+                "signature": region["name"],
+                "description": region["description"],
+                "path": dest,
+            }
+        )
+        context_queue.put(
+            ContextEntry(
+                archive=filename,
+                installPrefix=install_prefix,
+                extractPaths=[dest],
+                skipProcessingArchive=True,
+                omitUnrecognizedTypes=omit_unrecognized_types,
+            )
+        )
+
+    if not carved:
+        return None
+
+    covered = sum(int(c["length"]) for c in carved)
+    logger.info(f"binwalk_carver carved {len(carved)} region(s) from '{filename}' -> {out_dir}")
+    return {
+        _METADATA_KEY: {
+            "carved": True,
+            "extractPath": out_dir,
+            "imageSize": file_size,
+            "coveragePercent": round(covered / file_size * 100, 2) if file_size else None,
+            "regions": carved,
+        }
+    }
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> str:
+    return "binwalk_carver"
+
+
+@surfactant.plugin.hookimpl
+def settings_name() -> str:
+    return _SETTINGS_SECTION
+
+
+@surfactant.plugin.hookimpl
+def init_hook(command_name: str | None = None) -> None:
+    """Warn once if binwalk is unavailable before extraction runs."""
+    if command_name not in (None, "generate"):
+        return
+    if _binwalk_path() is None:
+        logger.warning(
+            "binwalk_carver: the 'binwalk' executable was not found on PATH; embedded "
+            "regions at non-zero offsets will not be carved. Install binwalk to enable "
+            "carving (e.g. 'cargo install binwalk' or 'pip install binwalk')."
+        )

--- a/plugins/binwalk-carver/surfactantplugin_binwalk_carver.py
+++ b/plugins/binwalk-carver/surfactantplugin_binwalk_carver.py
@@ -37,7 +37,6 @@ from loguru import logger
 import surfactant.plugin
 from surfactant import ContextEntry
 from surfactant.configmanager import ConfigManager
-from surfactant.sbomtypes import Software
 
 if TYPE_CHECKING:
     from queue import Queue
@@ -247,7 +246,7 @@ def _existing_carved_files(out_dir: str) -> list[str]:
     return [str(p) for p in sorted(pathlib.Path(out_dir).glob("carved_*")) if p.is_file()]
 
 
-# pylint: disable-next=too-many-positional-arguments
+# pylint: disable=too-many-positional-arguments
 @surfactant.plugin.hookimpl
 def extract_file_info(
     software: Software,
@@ -258,6 +257,7 @@ def extract_file_info(
     omit_unrecognized_types: bool = False,
 ) -> dict[str, Any] | None:
     """Carve non-zero-offset embedded regions out of ``filename`` and queue them."""
+    # pylint: disable=too-many-return-statements
     if _binwalk_path() is None:
         return None
 

--- a/plugins/ofrak-unpacker/README.md
+++ b/plugins/ofrak-unpacker/README.md
@@ -1,0 +1,100 @@
+# surfactantplugin-ofrak-unpacker
+
+A Surfactant plugin that unpacks **non-native firmware and embedded container
+formats** using [OFRAK](https://ofrak.com/), then hands the extracted artifacts
+back to Surfactant so the rest of the plugin pipeline (ELF/PE extractors,
+checksec, `angr-expanded`, relationship builders, ...) analyzes them.
+
+## Why
+
+Surfactant already decompresses common archives (ZIP, TAR, GZIP, BZIP2, XZ, RAR)
+via its built-in `file_decompression` extractor. Firmware images, however, use
+container formats that Surfactant does not handle natively. OFRAK knows how to
+unpack these, so this plugin bridges the two.
+
+This plugin **only unpacks** — it does not analyze the contents. It unpacks the
+container to a temporary directory and pushes a `ContextEntry` onto Surfactant's
+`context_queue`, which causes every other extractor to run on the extracted
+files automatically. Container provenance (`archive`, `installPrefix`) is
+preserved so `Contains` relationships and install paths appear in the SBOM.
+
+## Supported formats
+
+Detected by magic bytes in `identify_file_type`:
+
+| Label         | Format                                | Magic offset |
+| ------------- | ------------------------------------- | ------------ |
+| `SQUASHFS`    | SquashFS filesystem                   | `0x0`        |
+| `CRAMFS`      | CramFS filesystem                     | `0x0`        |
+| `JFFS2`       | JFFS2 filesystem                      | `0x0`        |
+| `UBI`         | UBI volume                            | `0x0`        |
+| `UBIFS`       | UBIFS filesystem                      | `0x0`        |
+| `EXT`         | ext2/3/4 filesystem                   | `0x438`      |
+| `YAFFS`       | YAFFS2 filesystem                     | `0x0`        |
+| `ISO9660`     | ISO 9660 disc image                   | `0x8001`     |
+| `UIMAGE`      | U-Boot legacy uImage                  | `0x0`        |
+| `OPENWRT_TRX` | OpenWrt TRX firmware container        | `0x0`        |
+| `UEFI`        | UEFI firmware volume                  | `0x28`       |
+| `CPIO`        | CPIO archive (initramfs, etc.)        | `0x0`        |
+| `SEVENZIP`    | 7-Zip archive                         | `0x0`        |
+| `UF2`         | UF2 flashing image                    | `0x0`        |
+| `ZSTD`        | Zstandard-compressed stream           | `0x0`        |
+| `LZOP`        | lzop (`.lzo`) compressed stream       | `0x0`        |
+| `IHEX`        | Intel HEX                             | (text scan) |
+| `DISK_IMAGE`  | MBR-partitioned disk image            | `0x1FE`      |
+| `GPT`         | GPT-partitioned disk image            | `0x200`      |
+
+## How it works
+
+1. `identify_file_type` tags the file with one of the labels above.
+2. `extract_file_info` runs OFRAK (`unpack_recursively`), flushing recovered
+   filesystem trees (or leaf resources) into a temporary directory.
+3. A `ContextEntry(archive=<file>, extractPaths=[<temp dir>],
+   skipProcessingArchive=True)` is queued so Surfactant re-processes the
+   extracted files with all extractors.
+4. Metadata about the unpacking is added to the archive's software entry under
+   the `ofrakUnpacker` key.
+
+## Metadata
+
+```json
+{
+  "ofrakUnpacker": {
+    "detectedFormats": ["SQUASHFS"],
+    "unpacked": true,
+    "extractPath": "/tmp/surfactant-ofrak-xxxx",
+    "extractedFileCount": 128,
+    "resourceTags": ["File", "Folder", "SquashfsFilesystem"]
+  }
+}
+```
+
+If OFRAK is not installed, the entry records `"unpacked": false` and unpacking is
+skipped (file-type identification still happens).
+
+## Installation
+
+OFRAK is an **optional** dependency because it is large and relies on external
+unpacker tooling. Install the plugin, then OFRAK separately if you want
+extraction:
+
+```bash
+# Enable extraction (heavy; may require system tools / Docker image deps):
+pip install ofrak
+# Once installed you must specify the license being used (community or pro)
+ofrak license
+```
+
+## Configuration
+
+| Section          | Key           | Default        | Meaning                                  |
+| ---------------- | ------------- | -------------- | ---------------------------------------- |
+| `ofrak_unpacker` | `extract_dir` | system tempdir | Base directory for extraction scratch    |
+
+## Notes / caveats
+
+- OFRAK is asyncio-based; the plugin wraps the async work internally.
+- OFRAK relies on external unpackers for many formats (often provided via its
+  Docker image). Those must be present in the environment for extraction to
+  succeed.
+- Extractions are cached by SHA-256, and temp directories are cleaned up at exit.

--- a/plugins/ofrak-unpacker/pyproject.toml
+++ b/plugins/ofrak-unpacker/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "surfactantplugin-ofrak-unpacker"
+version = "0.1.0"
+authors = [
+    {name = "Benton Wilson", email = "bwilson@nlr.gov"},
+]
+description = "Surfactant plugin that unpacks non-native firmware/container formats with OFRAK"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["surfactant", "ofrak", "sbom", "firmware", "unpacking"]
+license = "MIT"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Operating System :: POSIX :: Linux",
+]
+dependencies = [
+    "surfactant",
+]
+
+[project.optional-dependencies]
+# OFRAK is heavy and pulls external unpacker tooling; keep it optional.
+ofrak = ["ofrak"]
+
+[project.entry-points."surfactant"]
+"surfactantplugin_ofrak_unpacker" = "surfactantplugin_ofrak_unpacker"
+
+[tool.setuptools]
+py-modules = ["surfactantplugin_ofrak_unpacker"]

--- a/plugins/ofrak-unpacker/surfactantplugin_ofrak_unpacker.py
+++ b/plugins/ofrak-unpacker/surfactantplugin_ofrak_unpacker.py
@@ -40,6 +40,11 @@ if TYPE_CHECKING:
 
     from surfactant.sbomtypes import SBOM, Software
 
+# ``except Exception`` guards and the lazy ``ofrak`` imports below are intentional:
+# OFRAK is an optional dependency and unpacking untrusted firmware must never abort
+# SBOM generation for the rest of the corpus.
+# pylint: disable=broad-exception-caught,import-outside-toplevel
+
 # ---------------------------------------------------------------------------
 # File-type identification (magic bytes)
 # ---------------------------------------------------------------------------
@@ -331,11 +336,7 @@ def identify_file_type(filepath: str, context: ContextEntry | None = None) -> li
 
 
 def _ofrak_available() -> bool:
-    try:
-        import ofrak  # noqa: F401, PLC0415 - optional dependency probed lazily
-    except ImportError:
-        return False
-    return True
+    return importlib.util.find_spec("ofrak") is not None
 
 
 class _OfrakSession:
@@ -567,7 +568,7 @@ def _unpack_fs_with_ofrak(filename: str, out_dir: str) -> dict[str, Any]:
     return summary
 
 
-# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-positional-arguments,too-many-return-statements
 @surfactant.plugin.hookimpl
 def extract_file_info(
     sbom: SBOM,

--- a/plugins/ofrak-unpacker/surfactantplugin_ofrak_unpacker.py
+++ b/plugins/ofrak-unpacker/surfactantplugin_ofrak_unpacker.py
@@ -1,0 +1,747 @@
+# SPDX-License-Identifier: MIT
+"""Surfactant plugin that unpacks non-native firmware/container formats with OFRAK.
+
+Surfactant natively decompresses common archives (ZIP/TAR/GZIP/BZIP2/XZ/RAR) via
+``file_decompression.py``. This plugin extends that idea to firmware and embedded
+container formats that OFRAK knows how to unpack (SquashFS, CramFS, JFFS2, UBI/UBIFS,
+ext filesystems, U-Boot uImage, OpenWrt TRX, 7-Zip, ISO 9660, UEFI firmware volumes,
+UF2, CPIO, zstd/lzop streams, etc.).
+
+It works exactly like the built-in decompressor: it unpacks the container to a
+temporary directory and pushes ``ContextEntry`` objects onto Surfactant's
+``context_queue`` so the extracted artifacts are re-processed by the *entire* plugin
+pipeline (ELF/PE extractors, checksec, angr-expanded, relationship builders, ...).
+This plugin therefore does not analyze the contents itself; it only unpacks.
+
+OFRAK is an optional dependency. If it is not installed, ``identify_file_type`` still
+works (so the firmware type is still recorded), and ``extract_file_info`` logs a
+warning and skips unpacking.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+import importlib.util
+import pathlib
+import shutil
+import tempfile
+import threading
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+import surfactant.plugin
+from surfactant import ContextEntry
+from surfactant.configmanager import ConfigManager
+
+if TYPE_CHECKING:
+    from queue import Queue
+
+    from surfactant.sbomtypes import SBOM, Software
+
+# ---------------------------------------------------------------------------
+# File-type identification (magic bytes)
+# ---------------------------------------------------------------------------
+
+# Each entry maps a Surfactant file-type label to a (offset, signatures) pair.
+# ``signatures`` is a tuple of byte strings; a match at ``offset`` for any of them
+# identifies the type. These are the non-native container formats that OFRAK can
+# unpack but Surfactant does not handle on its own.
+#
+# ROMFS and Android boot images were intentionally dropped: OFRAK's core has no
+# unpacker for them, so identifying them here only produced empty extractions.
+# Device tree blobs (DTB) were also dropped: they describe hardware, contain no
+# software artifacts for the SBOM, and OFRAK's DtbUnpacker crashes on some of them.
+_MAGIC_SIGNATURES: dict[str, tuple[int, tuple[bytes, ...]]] = {
+    # SquashFS: "hsqs" (little-endian) or "sqsh" (big-endian) at offset 0
+    "SQUASHFS": (0, (b"hsqs", b"sqsh")),
+    # CramFS: 0x28cd3d45 stored little-endian at offset 0
+    "CRAMFS": (0, (b"\x45\x3d\xcd\x28",)),
+    # JFFS2: 0x1985 as either endianness at offset 0
+    "JFFS2": (0, (b"\x85\x19", b"\x19\x85")),
+    # UBI volume ("UBI#") and UBIFS at offset 0
+    "UBI": (0, (b"UBI#",)),
+    "UBIFS": (0, (b"\x31\x18\x10\x06",)),
+    # U-Boot legacy uImage: magic 0x27051956 at offset 0
+    "UIMAGE": (0, (b"\x27\x05\x19\x56",)),
+    # OpenWrt TRX firmware: magic "HDR0" (0x30524448 little-endian) at offset 0
+    "OPENWRT_TRX": (0, (b"HDR0",)),
+    # CPIO archives (newc/crc ASCII and old binary)
+    "CPIO": (0, (b"070701", b"070702", b"070707", b"\xc7\x71")),
+    # YAFFS2 object header (first record is typically a directory named for the root)
+    "YAFFS": (0, (b"\x03\x00\x00\x00\x01\x00\x00\x00\xff\xff",)),
+    # 7-Zip archive (not decompressed natively by Surfactant): magic at offset 0
+    "SEVENZIP": (0, (b"7z\xbc\xaf\x27\x1c",)),
+    # UF2 flashing format: first-block magic 0x0A324655 ("UF2\n") at offset 0
+    "UF2": (0, (b"\x55\x46\x32\x0a",)),
+    # Zstandard frame: magic 0xFD2FB528 stored little-endian at offset 0
+    "ZSTD": (0, (b"\x28\xb5\x2f\xfd",)),
+    # lzop (.lzo): magic \x89LZO\x00\r\n\x1a\n at offset 0
+    "LZOP": (0, (b"\x89\x4c\x5a\x4f\x00\x0d\x0a\x1a\x0a",)),
+    # UEFI firmware volume: "_FVH" signature at offset 0x28
+    "UEFI": (0x28, (b"_FVH",)),
+    # GPT-partitioned disk image: "EFI PART" at LBA 1 (offset 0x200)
+    "GPT": (0x200, (b"EFI PART",)),
+}
+
+# ext2/3/4 superblock magic 0xEF53 lives at offset 0x438, handled specially.
+_EXT_MAGIC_OFFSET = 0x438
+_EXT_MAGIC = b"\x53\xef"
+
+# ISO 9660 primary volume descriptor: "CD001" at offset 0x8001, handled specially
+# because it sits far past the header read used for the offset-0 signatures.
+_ISO_MAGIC_OFFSET = 0x8001
+_ISO_MAGIC = b"CD001"
+
+# MBR-partitioned disk image: 0x55AA boot signature at offset 0x1FE with at least
+# one non-empty partition table entry (checked specially to reduce false positives).
+_MBR_SIG_OFFSET = 0x1FE
+_MBR_SIG = b"\x55\xaa"
+_MBR_PART_TABLE_OFFSET = 0x1BE
+
+# The set of labels this plugin knows how to unpack.
+_SUPPORTED_TYPES = frozenset(_MAGIC_SIGNATURES) | {"EXT", "DISK_IMAGE", "ISO9660", "IHEX"}
+
+_METADATA_KEY = "ofrakUnpacker"
+_SETTINGS_SECTION = "ofrak_unpacker"
+
+# External CLI tools that OFRAK unpackers shell out to for the formats this plugin
+# detects (verified against ``python -m ofrak deps``). These must be present on
+# PATH for extraction of the corresponding formats to succeed. Package hints are
+# for Debian/Ubuntu. Maps tool -> (formats, install hint).
+_EXTERNAL_TOOLS: dict[str, tuple[str, str]] = {
+    "unsquashfs": ("SQUASHFS", "apt install squashfs-tools"),
+    "jefferson": ("JFFS2", "pip install jefferson"),
+    "debugfs": ("EXT", "apt install e2fsprogs"),
+    "7zz": ("SEVENZIP/CRAMFS/ISO9660", "apt install 7zip (or download from 7-zip.org)"),
+    "lzop": ("LZOP", "apt install lzop"),
+    "zstd": ("ZSTD", "apt install zstd"),
+    "uefiextract": ("UEFI", "download from https://github.com/LongSoft/UEFITool/releases"),
+}
+
+# Python modules certain OFRAK unpackers import directly (not PATH tools).
+# Maps importable module name -> (formats, install hint).
+_PYTHON_DEPS: dict[str, tuple[str, str]] = {
+    "lzo": ("UBI/UBIFS", "apt install liblzo2-dev && pip install python-lzo"),
+}
+
+# ---------------------------------------------------------------------------
+# Extraction bookkeeping
+# ---------------------------------------------------------------------------
+
+# sha256 -> extracted directory path, so repeated files are only unpacked once.
+# sha256 -> extracted directory path, so repeated files are only unpacked once.
+# Extraction directories are intentionally kept (not auto-deleted) so their
+# contents can be inspected and reused, mirroring Surfactant's built-in
+# file_decompression extractor.
+_EXTRACT_DIRS: dict[str, str] = {}
+
+_SECTOR_SIZE = 512
+# Extended-partition container types hold logical partitions rather than a
+# filesystem, so they are skipped (their logical partitions would be carved
+# separately in a fuller implementation).
+_EXTENDED_PART_TYPES = {0x05, 0x0F, 0x85}
+
+
+def _make_extract_dir() -> str:
+    base = ConfigManager().get(_SETTINGS_SECTION, "extract_dir", tempfile.gettempdir())
+    pathlib.Path(base).mkdir(parents=True, exist_ok=True)
+    return tempfile.mkdtemp(prefix="surfactant-ofrak-", dir=base)
+
+
+def _carve_range(src_path: str, offset: int, length: int, dest_path: str) -> int:
+    """Copy ``length`` bytes starting at ``offset`` from ``src_path`` to ``dest_path``."""
+    written = 0
+    with pathlib.Path(src_path).open("rb") as src, pathlib.Path(dest_path).open("wb") as out:
+        src.seek(offset)
+        remaining = length
+        while remaining > 0:
+            chunk = src.read(min(1 << 20, remaining))
+            if not chunk:
+                break
+            out.write(chunk)
+            written += len(chunk)
+            remaining -= len(chunk)
+    return written
+
+
+def _mbr_partitions(header: bytes, file_size: int) -> list[dict[str, int]]:
+    """Parse the four primary MBR partition-table entries."""
+    parts: list[dict[str, int]] = []
+    table = header[_MBR_PART_TABLE_OFFSET : _MBR_PART_TABLE_OFFSET + 64]
+    for i in range(4):
+        entry = table[i * 16 : (i + 1) * 16]
+        if len(entry) < 16:
+            break
+        ptype = entry[4]
+        lba_start = int.from_bytes(entry[8:12], "little")
+        num_sectors = int.from_bytes(entry[12:16], "little")
+        if ptype == 0 or num_sectors == 0 or ptype in _EXTENDED_PART_TYPES:
+            continue
+        offset = lba_start * _SECTOR_SIZE
+        if offset <= 0 or offset >= file_size:
+            continue
+        length = min(num_sectors * _SECTOR_SIZE, file_size - offset)
+        parts.append({"index": i, "type": ptype, "offset": offset, "length": length})
+    return parts
+
+
+def _gpt_partitions(src_path: str, file_size: int) -> list[dict[str, int]]:
+    """Parse the GPT partition entry array (header at LBA 1)."""
+    parts: list[dict[str, int]] = []
+    with pathlib.Path(src_path).open("rb") as f:
+        f.seek(_SECTOR_SIZE)
+        hdr = f.read(_SECTOR_SIZE)
+        if hdr[:8] != b"EFI PART":
+            return parts
+        part_entry_lba = int.from_bytes(hdr[72:80], "little")
+        num_entries = int.from_bytes(hdr[80:84], "little")
+        entry_size = int.from_bytes(hdr[84:88], "little")
+        if entry_size < 128 or num_entries == 0 or num_entries > 512:
+            return parts
+        f.seek(part_entry_lba * _SECTOR_SIZE)
+        table = f.read(num_entries * entry_size)
+    for i in range(num_entries):
+        entry = table[i * entry_size : (i + 1) * entry_size]
+        if len(entry) < 56:
+            break
+        if entry[0:16] == b"\x00" * 16:  # unused entry (zero type GUID)
+            continue
+        first_lba = int.from_bytes(entry[32:40], "little")
+        last_lba = int.from_bytes(entry[40:48], "little")
+        if last_lba < first_lba:
+            continue
+        offset = first_lba * _SECTOR_SIZE
+        if offset >= file_size:
+            continue
+        length = min((last_lba - first_lba + 1) * _SECTOR_SIZE, file_size - offset)
+        parts.append({"index": i, "type": 0xEE, "offset": offset, "length": length})
+    return parts
+
+
+def _carve_partitions(filename: str, out_dir: str) -> list[dict[str, Any]]:
+    """Carve each partition of an MBR/GPT disk image into ``out_dir``."""
+    file_size = pathlib.Path(filename).stat().st_size
+    with pathlib.Path(filename).open("rb") as f:
+        header = f.read(1088)
+
+    partitions: list[dict[str, int]] = []
+    if header[0x200:0x208] == b"EFI PART":
+        partitions = _gpt_partitions(filename, file_size)
+    if not partitions:
+        partitions = _mbr_partitions(header, file_size)
+
+    results: list[dict[str, Any]] = []
+    for p in partitions:
+        dest = str(pathlib.Path(out_dir) / f"partition_{p['index']}_type_0x{p['type']:02x}.img")
+        written = _carve_range(filename, p["offset"], p["length"], dest)
+        results.append(
+            {
+                "index": p["index"],
+                "partitionType": f"0x{p['type']:02x}",
+                "offset": p["offset"],
+                "length": written,
+                "path": dest,
+            }
+        )
+    return results
+
+
+def _existing_partition_files(out_dir: str) -> list[dict[str, Any]]:
+    return [
+        {"path": str(p), "length": p.stat().st_size}
+        for p in sorted(pathlib.Path(out_dir).glob("partition_*.img"))
+    ]
+
+
+def supports_file(filetype: list[str] | None) -> list[str] | None:
+    """Return the subset of ``filetype`` labels this plugin can unpack."""
+    if not filetype:
+        return None
+    supported = [ft for ft in filetype if ft in _SUPPORTED_TYPES]
+    return supported or None
+
+
+def _looks_like_ihex(header: bytes) -> bool:
+    """Validate that ``header`` begins with a well-formed Intel HEX record.
+
+    Intel HEX is ASCII, so a bare ``:`` prefix is far too weak. This parses the
+    first record and verifies its length field, record type, and checksum to
+    avoid misidentifying arbitrary text files that happen to start with a colon.
+    """
+    if not header.startswith(b":"):
+        return False
+    line = header[1:].split(b"\n", 1)[0].rstrip(b"\r")
+    if len(line) < 10 or len(line) % 2 != 0:
+        return False
+    try:
+        raw = bytes.fromhex(line.decode("ascii"))
+    except (ValueError, UnicodeDecodeError):
+        return False
+    byte_count = raw[0]
+    record_type = raw[3]
+    if record_type > 0x05 or len(raw) != byte_count + 5:
+        return False
+    return sum(raw) & 0xFF == 0
+
+
+@surfactant.plugin.hookimpl
+def identify_file_type(filepath: str, context: ContextEntry | None = None) -> list[str] | None:
+    """Identify non-native firmware/container formats by magic bytes."""
+    try:
+        with pathlib.Path(filepath).open("rb") as f:
+            header = f.read(1088)  # covers all offset-0 sigs plus the ext superblock
+            # ISO 9660's primary volume descriptor sits far past the header read,
+            # so grab just its signature separately (empty read past EOF is fine).
+            f.seek(_ISO_MAGIC_OFFSET)
+            iso_window = f.read(len(_ISO_MAGIC))
+    except OSError:
+        return None
+
+    matches: list[str] = []
+    for label, (offset, signatures) in _MAGIC_SIGNATURES.items():
+        window = header[offset : offset + max(len(s) for s in signatures)]
+        if any(window.startswith(sig) for sig in signatures):
+            matches.append(label)
+
+    if header[_EXT_MAGIC_OFFSET : _EXT_MAGIC_OFFSET + 2] == _EXT_MAGIC:
+        matches.append("EXT")
+
+    if iso_window == _ISO_MAGIC:
+        matches.append("ISO9660")
+
+    if _looks_like_ihex(header):
+        matches.append("IHEX")
+
+    # MBR disk image: boot signature plus a partition table entry with a non-zero
+    # partition type byte (offset +4 within a 16-byte entry). GPT protective MBRs
+    # also match, which is fine since GPT is detected separately above.
+    if header[_MBR_SIG_OFFSET : _MBR_SIG_OFFSET + 2] == _MBR_SIG:
+        part_types = [header[_MBR_PART_TABLE_OFFSET + i * 16 + 4] for i in range(4)]
+        if any(pt != 0 for pt in part_types):
+            matches.append("DISK_IMAGE")
+
+    return matches or None
+
+
+# ---------------------------------------------------------------------------
+# OFRAK unpacking
+# ---------------------------------------------------------------------------
+
+
+def _ofrak_available() -> bool:
+    try:
+        import ofrak  # noqa: F401, PLC0415 - optional dependency probed lazily
+    except ImportError:
+        return False
+    return True
+
+
+class _OfrakSession:
+    """A single long-lived OFRAK context shared across every file in a run.
+
+    Building an OFRAK context (service discovery, license verification, component
+    registration) takes several seconds. The plugin previously paid that cost
+    once *per file* via ``ofrak.OFRAK().run()``, which dominated runtime on
+    firmware images that expand into thousands of extractable containers.
+
+    This session starts one context on a dedicated background event loop and
+    reuses it for every unpack. Access is serialized with a lock because a single
+    OFRAK context (and its asyncio loop) is not safe to drive concurrently, and
+    OFRAK itself only allows one live context per process.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._context: Any = None
+        self._lock = threading.Lock()
+
+    def _ensure_started(self) -> None:
+        if self._context is not None:
+            return
+        import ofrak  # noqa: PLC0415 - lazy so the plugin loads without OFRAK installed
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, name="ofrak-session", daemon=True)
+        thread.start()
+        future = asyncio.run_coroutine_threadsafe(ofrak.OFRAK().create_ofrak_context(), loop)
+        self._context = future.result()
+        self._loop = loop
+        self._thread = thread
+        atexit.register(self.shutdown)
+
+    def run(self, coro_factory: Any) -> Any:
+        """Run ``coro_factory(context)`` on the shared context and return its result."""
+        with self._lock:
+            self._ensure_started()
+            future = asyncio.run_coroutine_threadsafe(coro_factory(self._context), self._loop)
+            return future.result()
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._context is None:
+                return
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._context.shutdown_context(), self._loop
+                )
+                future.result(timeout=30)
+            except Exception:  # noqa: BLE001
+                pass
+            self._context = None
+            if self._loop is not None:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+                self._loop = None
+            self._thread = None
+
+
+# Module-level singleton so every ``extract_file_info`` call reuses one context.
+_OFRAK_SESSION = _OfrakSession()
+
+
+async def _mapped_coverage(root_resource: Any) -> tuple[int, float] | None:
+    """Return ``(image_size, covered_fraction)`` for an unpacked OFRAK resource.
+
+    Coverage is the fraction of the original image's bytes that OFRAK mapped to
+    child resources. Only byte-mapped children are counted: content that OFRAK
+    decodes/decompresses into a separate data space (e.g. files inside a
+    compressed filesystem) is not mapped back onto the image, so an image that is
+    itself a single recognized container reports full (1.0) coverage. Unidentified
+    gaps (padding, unknown blobs) are left uncovered and lower the fraction.
+    """
+    try:
+        image_size = await root_resource.get_data_length()
+    except Exception:  # noqa: BLE001
+        return None
+    if not image_size:
+        return None
+
+    intervals: list[tuple[int, int]] = []
+
+    async def _walk(res: Any, base: int) -> None:
+        try:
+            children = await res.get_children()
+        except Exception:  # noqa: BLE001
+            return
+        for child in children:
+            try:
+                rng = await child.get_data_range_within_parent()
+            except Exception:  # noqa: BLE001
+                continue
+            # A zero-length range marks an unmapped (decoded) child that lives in
+            # its own data space, so it contributes no original-image bytes.
+            if rng.length() <= 0:
+                continue
+            start = base + rng.start
+            end = base + rng.end
+            if start < 0 or end > image_size or end <= start:
+                continue
+            intervals.append((start, end))
+            await _walk(child, start)
+
+    await _walk(root_resource, 0)
+
+    if not intervals:
+        # No mapped sub-regions: the whole image is one recognized container.
+        return image_size, 1.0
+
+    intervals.sort()
+    covered = 0
+    cur_start, cur_end = intervals[0]
+    for start, end in intervals[1:]:
+        if start > cur_end:
+            covered += cur_end - cur_start
+            cur_start, cur_end = start, end
+        else:
+            cur_end = max(cur_end, end)
+    covered += cur_end - cur_start
+    return image_size, covered / image_size
+
+
+def _unpack_fs_with_ofrak(filename: str, out_dir: str) -> dict[str, Any]:
+    """Unpack a single filesystem/container ``filename`` into ``out_dir`` with OFRAK.
+
+    OFRAK is asyncio-based, so the async work is wrapped and run to completion.
+    A recursive unpack gives the best coverage but can crash on a spurious match
+    (e.g. a false-positive device-tree blob inside an extracted file). Such
+    errors are tolerated: whatever filesystem trees were recovered are still
+    flushed to disk, and a single-level unpack is used as a fallback.
+    """
+    from ofrak.core.filesystem import FilesystemRoot  # noqa: PLC0415 - optional dependency
+
+    summary: dict[str, Any] = {"extractedFileCount": 0, "filesystemCount": 0}
+
+    async def _run(ofrak_context: Any) -> None:
+        root = await ofrak_context.create_root_resource_from_file(filename)
+        try:
+
+            async def _collect_fs_roots() -> list[Any]:
+                found: list[Any] = []
+                if root.has_tag(FilesystemRoot):
+                    found.append(root)
+                for descendant in await root.get_descendants():
+                    if descendant.has_tag(FilesystemRoot):
+                        found.append(descendant)
+                return found
+
+            # Shallow unpack first: for a resource that is itself a filesystem (e.g. an
+            # ext partition), a single-level unpack runs its dedicated unpacker and
+            # populates the whole tree quickly, without recursing into every extracted
+            # file. Recursing eagerly is both slow and prone to crashing on a spurious
+            # match inside one of the extracted files, which previously left the
+            # filesystem tagged-but-empty.
+            try:
+                await root.unpack()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(f"OFRAK shallow unpack of {filename} failed: {exc}")
+
+            fs_resources = await _collect_fs_roots()
+            have_populated = False
+            for fsr in fs_resources:
+                try:
+                    if list(await fsr.get_children()):
+                        have_populated = True
+                        break
+                except Exception:  # noqa: BLE001
+                    continue
+
+            # Only dig deeper when the shallow unpack did not already yield a populated
+            # filesystem. This handles wrapper formats (uImage/TRX/etc.) that must be
+            # peeled back a few layers before a filesystem is exposed. A crashing
+            # sub-unpacker here is tolerated.
+            if not have_populated:
+                try:
+                    await root.unpack_recursively()
+                except Exception as exc:  # noqa: BLE001 - tolerate crashing sub-unpackers
+                    logger.warning(f"OFRAK recursive unpack of {filename} hit an error: {exc}")
+                fs_resources = await _collect_fs_roots()
+
+            # A crashing sub-unpacker can abort a recursive pass *after* a filesystem
+            # was identified (tagged) but *before* its dedicated unpacker populated it,
+            # leaving an empty tree. Explicitly unpack any filesystem that still has no
+            # children so its contents are recovered (e.g. ext via debugfs), tolerating
+            # per-resource errors so one bad filesystem can't block the others.
+            for fsr in fs_resources:
+                try:
+                    if not list(await fsr.get_children()):
+                        await fsr.unpack()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"OFRAK failed to populate a filesystem in {filename}: {exc}")
+
+            # Re-collect: populating a filesystem may have exposed nested filesystem roots.
+            fs_resources = await _collect_fs_roots()
+
+            for idx, fsr in enumerate(fs_resources):
+                dest = pathlib.Path(out_dir) / f"filesystem_{idx}"
+                dest.mkdir(parents=True, exist_ok=True)
+                try:
+                    view = await fsr.view_as(FilesystemRoot)
+                    await view.flush_to_disk(str(dest))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"OFRAK failed to flush filesystem_{idx} of {filename}: {exc}")
+
+            summary["filesystemCount"] = len(fs_resources)
+            summary["extractedFileCount"] = sum(
+                1 for p in pathlib.Path(out_dir).rglob("*") if p.is_file()
+            )
+
+            coverage = await _mapped_coverage(root)
+            if coverage is not None:
+                image_size, fraction = coverage
+                summary["imageSize"] = image_size
+                summary["coveragePercent"] = round(fraction * 100, 2)
+        finally:
+            # The OFRAK context is shared across every file in the run, so the
+            # resource tree for this file must be released once it has been
+            # flushed to disk; otherwise the whole firmware image's worth of
+            # unpacked filesystems would pile up in memory.
+            try:
+                await root.delete()
+                await root.save()
+            except Exception:  # noqa: BLE001
+                pass
+
+    _OFRAK_SESSION.run(_run)
+    return summary
+
+
+# pylint: disable=too-many-positional-arguments
+@surfactant.plugin.hookimpl
+def extract_file_info(
+    sbom: SBOM,
+    software: Software,
+    filename: str,
+    filetype: list[str],
+    context_queue: Queue[ContextEntry],
+    current_context: ContextEntry | None,
+    omit_unrecognized_types: bool = False,
+) -> dict[str, Any] | None:
+    supported = supports_file(filetype)
+    if not supported:
+        # ``identify_file_type`` is a ``firstresult=True`` hook, so only the first
+        # plugin to return a non-None result wins and that single label list is
+        # what gets passed here. The built-in magic identifier runs ``tryfirst``
+        # and may win with a label this plugin does not use (e.g. "ZSTANDARD" vs
+        # "ZSTD", "ISO_9660_CD" vs "ISO9660") or return nothing for formats it
+        # doesn't know (e.g. MBR disk images), which would shadow our own
+        # detection. Re-run our own magic-based identification on the file so we
+        # still unpack any format we support, regardless of who won the race.
+        supported = supports_file(identify_file_type(filename))
+    if not supported:
+        return None
+
+    # Avoid re-extracting an archive we're already inside of.
+    if current_context and current_context.archive == filename and current_context.extractPaths:
+        return None
+
+    # Inherit the install prefix from the parent context, if any.
+    install_prefix = current_context.installPrefix if current_context else ""
+    is_disk_image = any(t in ("DISK_IMAGE", "GPT") for t in supported)
+
+    # Reuse a previous extraction of identical bytes.
+    out_dir = _EXTRACT_DIRS.get(software.sha256)
+    reused = bool(out_dir and pathlib.Path(out_dir).exists())
+    if not reused:
+        out_dir = _make_extract_dir()
+        _EXTRACT_DIRS[software.sha256] = out_dir
+
+    if is_disk_image:
+        # Partition carving is pure-Python; OFRAK has no MBR/GPT unpacker.
+        try:
+            partitions = (
+                _existing_partition_files(out_dir)
+                if reused
+                else _carve_partitions(filename, out_dir)
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.opt(exception=True).error(f"Failed to carve partitions from {filename}: {exc}")
+            return {
+                _METADATA_KEY: {
+                    "detectedFormats": supported,
+                    "unpacked": False,
+                    "error": str(exc),
+                }
+            }
+
+        if not partitions:
+            logger.warning(f"No partitions carved from disk image {filename}")
+            return {_METADATA_KEY: {"detectedFormats": supported, "unpacked": False}}
+
+        for part in partitions:
+            context_queue.put(
+                ContextEntry(
+                    archive=filename,
+                    installPrefix=install_prefix,
+                    extractPaths=[part["path"]],
+                    skipProcessingArchive=True,
+                    omitUnrecognizedTypes=True,
+                )
+            )
+        logger.info(
+            f"Carved {len(partitions)} partition(s) from {supported} '{filename}' -> {out_dir}"
+        )
+        image_size = pathlib.Path(filename).stat().st_size
+        covered = sum(int(p.get("length", 0)) for p in partitions)
+        coverage_percent = round(covered / image_size * 100, 2) if image_size else None
+        return {
+            _METADATA_KEY: {
+                "detectedFormats": supported,
+                "unpacked": True,
+                "extractPath": out_dir,
+                "partitions": partitions,
+                "imageSize": image_size,
+                "coveragePercent": coverage_percent,
+            }
+        }
+
+    # Filesystem/container formats require OFRAK.
+    if not _ofrak_available():
+        logger.warning(
+            f"OFRAK is not installed; cannot unpack {supported} file {filename}. "
+            "Install with 'pip install ofrak' to enable extraction."
+        )
+        return {_METADATA_KEY: {"detectedFormats": supported, "unpacked": False}}
+
+    if reused:
+        summary: dict[str, Any] = {"cached": True}
+    else:
+        try:
+            summary = _unpack_fs_with_ofrak(filename, out_dir)
+        except Exception as exc:  # noqa: BLE001 - surface OFRAK errors without crashing
+            logger.opt(exception=True).error(f"OFRAK failed to unpack {filename}: {exc}")
+            return {
+                _METADATA_KEY: {
+                    "detectedFormats": supported,
+                    "unpacked": False,
+                    "error": str(exc),
+                }
+            }
+
+    context_queue.put(
+        ContextEntry(
+            archive=filename,
+            installPrefix=install_prefix,
+            extractPaths=[out_dir],
+            skipProcessingArchive=True,
+            omitUnrecognizedTypes=True,
+        )
+    )
+    logger.info(f"OFRAK unpacked {supported} '{filename}' -> {out_dir}")
+
+    return {
+        _METADATA_KEY: {
+            "detectedFormats": supported,
+            "unpacked": True,
+            "extractPath": out_dir,
+            **summary,
+        }
+    }
+
+
+@surfactant.plugin.hookimpl
+def short_name() -> str:
+    return "ofrak_unpacker"
+
+
+@surfactant.plugin.hookimpl
+def settings_name() -> str:
+    return _SETTINGS_SECTION
+
+
+@surfactant.plugin.hookimpl
+def init_hook(command_name: str | None = None) -> None:
+    """Warn once about missing OFRAK dependencies before extraction runs.
+
+    Only the ``generate`` command performs extraction, so the checks are skipped
+    for unrelated commands to avoid spurious warnings.
+    """
+    if command_name not in (None, "generate"):
+        return
+
+    if not _ofrak_available():
+        logger.warning(
+            "ofrak_unpacker: OFRAK is not installed; firmware/container formats "
+            "will still be identified but cannot be unpacked. Install with "
+            "'pip install ofrak' to enable extraction."
+        )
+        return
+
+    missing = [
+        f"{tool} [{fmt}] (install: {hint})"
+        for tool, (fmt, hint) in _EXTERNAL_TOOLS.items()
+        if shutil.which(tool) is None
+    ]
+    missing += [
+        f"{module} [{fmt}] (install: {hint})"
+        for module, (fmt, hint) in _PYTHON_DEPS.items()
+        if importlib.util.find_spec(module) is None
+    ]
+    if missing:
+        logger.warning(
+            "ofrak_unpacker: the following OFRAK unpacking dependencies were not "
+            "found; the corresponding formats cannot be extracted: " + ", ".join(missing)
+        )
+    else:
+        logger.info("ofrak_unpacker: OFRAK and all checked unpacking dependencies are available.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "defusedxml==0.7.*",
     "spdx-tools==0.8.*",
     # Pinned to specific version for potential breaking changes
-    "cyclonedx-python-lib==11.11.0",
+    "cyclonedx-python-lib==11.12.0",
     "pluggy==1.*",
     "click==8.*",
     "loguru==0.7.*",


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details.
If appropriate, fill in the following sections. Please tag linked issues. e.g. This PR fixes issue #1234-->

### Summary

This PR adds four independent, complementary Surfactant plugins. Each does one focused job and deliberately avoids duplicating the others' output, keeping SBOM generation  metadata non-redundant. All are optional: if a plugin's runtime dependency (OFRAK, binwalk, Binary Ninja, angr) is missing, it logs a warning once and skips generation is never blocked. More info found in each individual README.

<!-- please finish the following statement -->

If merged this pull request will add in support for each of the 4 above plugins.

### Proposed changes

<!-- Describe the highlights of the proposed changes here -->

Uses OFRAK (third-party, actively maintained) as the main extractor. Identifies containers by magic bytes at offset 0 and unpacks them properly, then re-queues the contents through Surfactant's pipeline.

Binwalk/Carver shells out to binwalk to locate embedded regions, carves each region that starts at a non-zero offset into its own file (so its magic now sits at offset 0), and re-queues it for OFRAK/native identification.

Binja focuses on high-fidelity function recovery and per-function CFGs. Loads binaries in cheap controlFlow analysis mode. (NOTE: Requires a license)

Angr extracts loader/arch/symbol details and establish Uses relationships between binaries by matching imports to exports. Differs from native angr by filling SBOM with generated info instead of outputting to external file


